### PR TITLE
workaround for nion declaration execution at import time

### DIFF
--- a/lib/configure/index.js
+++ b/lib/configure/index.js
@@ -24,10 +24,6 @@ exports.default = function (_ref) {
         csrfProvider = _ref.csrfProvider,
         defaultApiUrl = _ref.defaultApiUrl;
 
-    if (Object.keys(apiModules).length === 0) {
-        throw new Error('nion requires at least one API module. Please supply an API module in nion.configureNion');
-    }
-
     if (apiModules) {
         (0, _lodash2.default)(apiModules, function (apiModule, name) {
             _api2.default.registerApi(name, apiModule);

--- a/src/configure/index.js
+++ b/src/configure/index.js
@@ -4,12 +4,6 @@ import ApiManager from '../api'
 import map from 'lodash.map'
 
 export default ({ apiModules, defaultApi, csrfProvider, defaultApiUrl }) => {
-    if (Object.keys(apiModules).length === 0) {
-        throw new Error(
-            'nion requires at least one API module. Please supply an API module in nion.configureNion',
-        )
-    }
-
     if (apiModules) {
         map(apiModules, (apiModule, name) => {
             ApiManager.registerApi(name, apiModule)

--- a/src/nion-modules/json-api/build-url/index.js
+++ b/src/nion-modules/json-api/build-url/index.js
@@ -3,12 +3,11 @@ import urlFactory from 'url-factory'
 // eventually make this configurable via nion api-module config interface
 const CURRENT_JSON_API_VERSION = '1.0'
 
-export const urlBuilderForDefaults = (apiHost, defaults) => {
-    return urlFactory(apiHost, {
+export const urlBuilderForDefaults = (apiHost, defaults) =>
+    urlFactory(apiHost, {
         'json-api-version': CURRENT_JSON_API_VERSION,
         ...defaults,
     })
-}
 
 export default apiHost => {
     return urlBuilderForDefaults(apiHost, { include: [] })


### PR DESCRIPTION
Removing the api-module config requirement when calling configureNion. This is unfortunately necessary to get around nion declaration url resolutions at import time