### PR TITLE
the displayName of a react component is a static property

### DIFF
--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -355,7 +355,7 @@ const nion = (declarations = {}, ...rest) => WrappedComponent => {
     const fetchesByDataKey = {}
 
     class WithNion extends Component {
-        displayName = `WithNion(${getDisplayName(WrappedComponent)})`
+        static displayName = `WithNion(${getDisplayName(WrappedComponent)})`
 
         static propTypes = {
             nion: PropTypes.object.isRequired,


### PR DESCRIPTION
I'm seeing e.g. `Connect(WithNion)` in my logging of display names. I think this is because this class sets `displayName` as an instance property, not static property.