### PR TITLE
Catch render errors caused by API failures

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -119,22 +119,35 @@ var apiAction = function apiAction(method, dataKey, options) {
                             case 22:
                                 _context.prev = 22;
                                 _context.t0 = _context['catch'](2);
-                                _context.next = 26;
+                                _context.prev = 24;
+                                _context.next = 27;
                                 return dispatch({
                                     type: _types.NION_API_FAILURE,
                                     meta: meta,
                                     payload: _context.t0
                                 });
 
-                            case 26:
+                            case 27:
+                                _context.next = 32;
+                                break;
+
+                            case 29:
+                                _context.prev = 29;
+                                _context.t1 = _context['catch'](24);
+
+                                // We probably want to catch any render errors here, logging them but actually
+                                // throwing the api error that caused it
+                                console.error(_context.t1);
+
+                            case 32:
                                 throw _context.t0;
 
-                            case 27:
+                            case 33:
                             case 'end':
                                 return _context.stop();
                         }
                     }
-                }, _callee, undefined, [[2, 22]]);
+                }, _callee, undefined, [[2, 22], [24, 29]]);
             }));
 
             return function (_x, _x2) {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -73,12 +73,17 @@ const apiAction = (method, dataKey, options) => _dispatch => {
 
             return selectData(dataKey)(getState())
         } catch (error) {
-            await dispatch({
-                type: NION_API_FAILURE,
-                meta,
-                payload: error,
-            })
-
+            try {
+                await dispatch({
+                    type: NION_API_FAILURE,
+                    meta,
+                    payload: error,
+                })
+            } catch (renderError) {
+                // We probably want to catch any render errors here, logging them but actually
+                // throwing the api error that caused it
+                console.error(renderError)
+            }
             throw error
         }
     })


### PR DESCRIPTION
API errors that wind up triggering a render error are swallowed in a funny way by nion at the moment. This PR wraps the dispatch of an error message itself (this can trigger renders that aren't handled properly) in a try/catch, which then makes sure that if a render error is thrown the original API error is thrown instead. This makes it a lot easier to debug erroneous API requests