### PR TITLE
Fix splatting out array into an object for normal 'api' type

### DIFF
--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -132,7 +132,9 @@ function processDeclarations(inputDeclarations, ...rest) {
             map(extraProps, prop => {
                 const extraProp =
                     typeof selected[prop] === 'object'
-                        ? { ...selected[prop] }
+                        ? declarations[selectedDataKey].apiType === 'api'
+                          ? selected[prop]
+                          : { ...selected[prop] }
                         : selected[prop]
                 defineDataProperty(nion[key], prop, extraProp)
             })


### PR DESCRIPTION
Because `typeof [] === 'object'`, we were accidentally splatting out arrays into objects

e.g.
API response of:
```js
{
    labels: ['I', 'am', 'a', 'label', 'array']
}
```
would splat into
```js
{
    labels: {
        0: 'I',
        1: 'am',
        2: 'a',
        3: 'label',
        4: 'array',
    }
}
```