### PR TITLE
Add in custom response json parser at the declaration level

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -53,7 +53,7 @@ var apiAction = function apiAction(method, dataKey, options) {
         // Return our async / thunk API call manager
         return _dispatch(function () {
             var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(dispatch, getState) {
-                var requestParams, response, text, json, status, statusText;
+                var requestParams, response, text, json, status, statusText, parseResponse, responseData;
                 return _regenerator2.default.wrap(function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -103,38 +103,47 @@ var apiAction = function apiAction(method, dataKey, options) {
                                 throw new ErrorClass(status, statusText, (0, _extends3.default)({}, response, json));
 
                             case 17:
-                                _context.next = 19;
+
+                                // If a parseResponse parameter is supplied to the declaration, we'll want to parse the
+                                // data with both the parseResponse function and the api module parse function
+                                parseResponse = declaration.parseResponse;
+
+                                json = parseResponse ? parseResponse(json) : json;
+
+                                // Parse the data with the parser from the API module
+                                responseData = parse(json);
+                                _context.next = 22;
                                 return dispatch({
                                     type: _types.NION_API_SUCCESS,
                                     meta: meta,
                                     payload: {
                                         requestType: apiType,
-                                        responseData: parse(json)
+                                        responseData: responseData
                                     }
                                 });
 
-                            case 19:
+                            case 22:
                                 return _context.abrupt('return', (0, _selectors.selectData)(dataKey)(getState()));
 
-                            case 22:
-                                _context.prev = 22;
+                            case 25:
+                                _context.prev = 25;
                                 _context.t0 = _context['catch'](2);
-                                _context.next = 26;
+                                _context.next = 29;
                                 return dispatch({
                                     type: _types.NION_API_FAILURE,
                                     meta: meta,
                                     payload: _context.t0
                                 });
 
-                            case 26:
+                            case 29:
                                 throw _context.t0;
 
-                            case 27:
+                            case 30:
                             case 'end':
                                 return _context.stop();
                         }
                     }
-                }, _callee, undefined, [[2, 22]]);
+                }, _callee, undefined, [[2, 25]]);
             }));
 
             return function (_x, _x2) {

--- a/lib/decorator/index.js
+++ b/lib/decorator/index.js
@@ -91,7 +91,10 @@ var defaultDeclarationOptions = {
     apiType: _api2.default.getDefaultApi(),
 
     // Set custom request parameters
-    requestParams: {}
+    requestParams: {},
+
+    // Custom response json parser for the declaration: (json) => parsed
+    parseResponse: undefined
 };
 
 function processDefaultOptions(declarations) {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -51,7 +51,7 @@ const apiAction = (method, dataKey, options) => _dispatch => {
 
             // Handle the case that calling response.json() on null responses throws a syntax error
             const text = await response.text()
-            const json = text ? JSON.parse(text) : {}
+            let json = text ? JSON.parse(text) : {}
 
             // Handle any request errors since fetch doesn't throw
             if (!response.ok) {
@@ -62,12 +62,20 @@ const apiAction = (method, dataKey, options) => _dispatch => {
                 })
             }
 
+            // If a parseResponse parameter is supplied to the declaration, we'll want to parse the
+            // data with both the parseResponse function and the api module parse function
+            const { parseResponse } = declaration
+            json = parseResponse ? parseResponse(json) : json
+
+            // Parse the data with the parser from the API module
+            const responseData = parse(json)
+
             await dispatch({
                 type: NION_API_SUCCESS,
                 meta,
                 payload: {
                     requestType: apiType,
-                    responseData: parse(json),
+                    responseData,
                 },
             })
 

--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -29,6 +29,9 @@ const defaultDeclarationOptions = {
 
     // Set custom request parameters
     requestParams: {},
+
+    // Custom response json parser for the declaration: (json) => parsed
+    parseResponse: undefined,
 }
 
 function processDefaultOptions(declarations) {


### PR DESCRIPTION
**Problem:** There's a few situations where our API doesn't return JSON-API data, and that's more or less the correct behavior - specifically, when fetching discord roles, we make a request to the patreon API that simply forwards data from the discord role server, and doesn't format it as JSON-API. This is correct, since it's not data that we "own", but it does break in nion since our json-api module expects json-api-shaped data.

This PR gives us the ability to parse the response json data at the declaration level **before** the nion-module parses the response, which allows us to manipulate the data in a way to make it compatible with the API module in these limited contexts.