### PR TITLE
make the csrfProvider pattern a more generic headersProvider

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -8,7 +8,7 @@ class ApiManager {
     apiMap = {}
     defaultApiType = null
     defaultApiUrl = null
-    csrfProvider = null
+    headersProvider = null
 
     getApiModule = apiType => {
         if (this.apiMap[apiType]) {
@@ -25,7 +25,7 @@ class ApiManager {
         return this.getApiModule(apiType).request.getRequestParameters(
             method,
             options,
-            this.csrfProvider,
+            this.headersProvider,
         )
     }
 
@@ -80,9 +80,9 @@ class ApiManager {
         this.defaultApiUrl = url
     }
 
-    setCsrfProvider = csrfProvider => {
-        if (csrfProvider) {
-            this.csrfProvider = csrfProvider
+    setHeadersProvider = headersProvider => {
+        if (headersProvider) {
+            this.headersProvider = headersProvider
         }
     }
 }

--- a/src/configure/index.js
+++ b/src/configure/index.js
@@ -3,7 +3,7 @@ import ApiManager from '../api'
 
 import map from 'lodash.map'
 
-export default ({ apiModules, defaultApi, csrfProvider, defaultApiUrl }) => {
+export default ({ apiModules, defaultApi, headersProvider, defaultApiUrl }) => {
     if (apiModules) {
         map(apiModules, (apiModule, name) => {
             ApiManager.registerApi(name, apiModule)
@@ -12,8 +12,8 @@ export default ({ apiModules, defaultApi, csrfProvider, defaultApiUrl }) => {
         ApiManager.setDefaultApi(defaultApi)
     }
 
-    if (csrfProvider) {
-        ApiManager.setCsrfProvider(csrfProvider)
+    if (headersProvider) {
+        ApiManager.setHeadersProvider(headersProvider)
     }
 
     // eventually we need to break this out and make it an config

--- a/src/nion-modules/json-api/request/index.js
+++ b/src/nion-modules/json-api/request/index.js
@@ -64,19 +64,11 @@ export const afterRequest = (method, options) => {
     return Promise.resolve()
 }
 
-export const getRequestParameters = (method, options, csrfProvider) => {
+export const getRequestParameters = (method, options, headersProvider) => {
     return Promise.resolve()
         .then(() => {
-            const skipMethods = {
-                get: true,
-                options: true,
-            }
-            if (skipMethods[method.toLowerCase()]) {
-                return
-            }
-
-            if (csrfProvider) {
-                return csrfProvider()
+            if (headersProvider) {
+                return headersProvider(method.toLowerCase())
             }
         })
         .then(headers => ({


### PR DESCRIPTION
**Problem**
Right now, there is no way to globally edit the headers used in our HTTP requests, except as part of the `csrfProvider` configuration hook. However, this hook is ignored for HTTP `GET` and `OPTIONS` requests.

**Solution**
Make the hook a more generic `headersProvider`, and let it customize headers for all HTTP methods. The HTTP Method is provided to the hook, if it wants to skip customization for certain methods.