### PR TITLE
fix `TypeError: Cannot read property 'apiType' of undefined`

### DIFF
--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -131,10 +131,9 @@ function processDeclarations(inputDeclarations, ...rest) {
             const extraProps = Object.keys(omit(selected, ['obj', 'request']))
             map(extraProps, prop => {
                 const extraProp =
-                    typeof selected[prop] === 'object'
-                        ? declarations[selectedDataKey].apiType === 'api'
-                          ? selected[prop]
-                          : { ...selected[prop] }
+                    typeof selected[prop] === 'object' &&
+                    get(declarations, `${selectedDataKey}.apiType`) !== 'api'
+                        ? { ...selected[prop] }
                         : selected[prop]
                 defineDataProperty(nion[key], prop, extraProp)
             })


### PR DESCRIPTION
guard against the declaration and/or the declaration’s selected data key being null when determining which extra props to inject