### PR TITLE
Make the requests reducer pure

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -64,7 +64,10 @@ const apiAction = (method, dataKey, options) => _dispatch => {
 
             await dispatch({
                 type: NION_API_SUCCESS,
-                meta,
+                meta: {
+                    ...meta,
+                    fetchedAt: Date.now(),
+                },
                 payload: {
                     requestType: apiType,
                     responseData: parse(json),
@@ -76,7 +79,10 @@ const apiAction = (method, dataKey, options) => _dispatch => {
             try {
                 await dispatch({
                     type: NION_API_FAILURE,
-                    meta,
+                    meta: {
+                        ...meta,
+                        fetchedAt: Date.now(),
+                    },
                     payload: error,
                 })
             } catch (renderError) {

--- a/src/reducers/requests.js
+++ b/src/reducers/requests.js
@@ -28,7 +28,7 @@ const requestsReducer = (state = initialState, action) => {
                 [action.meta.dataKey]: {
                     ...existing,
                     status: 'success',
-                    fetchedAt: Date.now(),
+                    fetchedAt: action.meta.fetchedAt,
                     isError: false,
                     isLoaded: true,
                     isLoading: false,
@@ -42,7 +42,7 @@ const requestsReducer = (state = initialState, action) => {
                     status: 'error',
                     name: action.payload.name,
                     errors: action.payload.errors,
-                    fetchedAt: Date.now(),
+                    fetchedAt: action.meta.fetchedAt,
                     isError: true,
                     isLoaded: false,
                     isLoading: false,


### PR DESCRIPTION
make the request actions encode when they occurred, rather than having an impure reducer