### PR TITLE
Update nion module to not overwrite relationships / attributes

### DIFF
--- a/lib/api-modules/json-api/parser/index.js
+++ b/lib/api-modules/json-api/parser/index.js
@@ -17,10 +17,15 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var addEntityToStoreFragment = function addEntityToStoreFragment(store) {
     var entity = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    // It's important to have default attributes and relationships here, since we can accidentally
+    // overwrite these keys when we merge the fragment into the redux store if they are undefined
     var type = entity.type,
         id = entity.id,
-        attributes = entity.attributes,
-        relationships = entity.relationships;
+        _entity$attributes = entity.attributes,
+        attributes = _entity$attributes === undefined ? {} : _entity$attributes,
+        _entity$relationships = entity.relationships,
+        relationships = _entity$relationships === undefined ? {} : _entity$relationships;
 
     if (!entity) {
         return;
@@ -28,6 +33,7 @@ var addEntityToStoreFragment = function addEntityToStoreFragment(store) {
     if (!(type in store)) {
         store[type] = {};
     }
+
     store[type][id] = {
         type: type,
         id: id,

--- a/src/api-modules/json-api/parser/index.js
+++ b/src/api-modules/json-api/parser/index.js
@@ -2,18 +2,21 @@ import map from 'lodash.map'
 import every from 'lodash.every'
 
 const addEntityToStoreFragment = (store, entity = {}) => {
-    const { type, id, attributes, relationships } = entity
+    // It's important to have default attributes and relationships here, since we can accidentally
+    // overwrite these keys when we merge the fragment into the redux store if they are undefined
+    const { type, id, attributes = {}, relationships = {} } = entity
     if (!entity) {
         return
     }
     if (!(type in store)) {
         store[type] = {}
     }
+
     store[type][id] = {
-        type: type,
-        id: id,
-        attributes: attributes,
-        relationships: relationships,
+        type,
+        id,
+        attributes,
+        relationships,
     }
 }
 


### PR DESCRIPTION
In the upcoming seamless-immutable nion redux state world, merging in a key that's explicitly `undefined` will cause it to be erased from the store. This causes requests that contain no relationships to wipe out any preexisting relationships in the store. In the old world, using `{ ...obj.relationships }` to spread out undefined just keeps the existing relationships.

This PR adds default empty object values to relationships and attributes, which will work the same way in our reducers with both regular redux state or immutable state