### PR TITLE
Fix for multi-decorated components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3999,7 +3999,6 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
             "requires": {
                 "is-primitive": "2.0.0"
             }
@@ -4105,8 +4104,7 @@
         "is-primitive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
         "is-property": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "deep-equal": "^1.0.1",
         "fast-url-parser": "^1.1.3",
         "humps": "^2.0.1",
+        "is-equal-shallow": "^0.1.3",
         "isomorphic-fetch": "github:patreon/isomorphic-fetch#e4f90061be5fabed8fde118b04585478bfe185b2",
         "lodash.difference": "^4.5.0",
         "lodash.every": "^4.6.0",

--- a/src/decorator/should-rerender.js
+++ b/src/decorator/should-rerender.js
@@ -1,8 +1,16 @@
 import difference from 'lodash.difference'
 import every from 'lodash.every'
 import get from 'lodash.get'
+import omit from 'lodash.omit'
+import shallowEqual from 'is-equal-shallow'
 import deepEqual from 'deep-equal'
 import { hasEntityReference } from '../denormalize'
+
+function areNonNionDataEqual(props, nextProps) {
+    const prevNonNionData = omit(props, ['nion'])
+    const nextNonNionData = omit(nextProps, ['nion'])
+    return shallowEqual(prevNonNionData, nextNonNionData)
+}
 
 function getDataPropertyKeys(obj) {
     const enumerableKeys = Object.keys(obj)
@@ -84,6 +92,10 @@ function areEntityListsEqual(prevFlatEntities, nextFlatEntities) {
 }
 
 export function areMergedPropsEqual(nextProps, props) {
+    if (!areNonNionDataEqual(props, nextProps)) {
+        return false
+    }
+
     const keysToIgnore = ['_initializeDataKey', 'updateEntity', '_declarations']
     const prevNionKeys = difference(Object.keys(props.nion), keysToIgnore)
     const nextNionKeys = difference(Object.keys(nextProps.nion), keysToIgnore)


### PR DESCRIPTION
if there is a decorator like `@connect` wrapping a `@nion` decoration, then are non-nion properties, and we should shallowEqual them (the default react-redux connect algorithm) to determine if we should re-render