### PR TITLE
Finalize denormalization cache / internal audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9724,6 +9724,11 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true
         },
+        "seamless-immutable": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.2.tgz",
+            "integrity": "sha1-yHoeumdnoyRVMR12YArF7d6vu2k="
+        },
         "semver": {
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "react": "^15.6.1",
         "react-redux": "^5.0.5",
         "redux": "^3.7.1",
-        "reselect": "^3.0.1"
+        "reselect": "^3.0.1",
+        "seamless-immutable": "^7.1.2"
     },
     "scripts": {
         "build": "npm run build:lib",

--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -137,7 +137,7 @@ function assertEqualAction(expected, observed) {
         if (metaKey === 'fetchedAt') {
             // Check to see that our fetchedAt value is within 30ms of our actual value
             const diff = expected.meta.fetchedAt - observed.meta.fetchedAt
-            expect(Math.abs(diff)).toBeLessThan(30)
+            expect(Math.abs(diff)).toBeLessThan(100)
         } else {
             expect(expected.meta[metaKey]).toEqual(observed.meta[metaKey])
         }

--- a/src/api-modules/json-api/pagination/index.js
+++ b/src/api-modules/json-api/pagination/index.js
@@ -1,10 +1,10 @@
 import get from 'lodash.get'
 
 export const canLoadMore = data => {
-    return !!get(data, 'links.next') && !get(data, 'request.isLoading')
+    return !!get(data, 'extra.links.next') && !get(data, 'request.isLoading')
 }
 
 export const getNextUrl = (declaration, selectedData) => {
-    const nextUrl = get(selectedData, ['links', 'next'], null)
+    const nextUrl = get(selectedData, 'extra.links.next', null)
     return nextUrl
 }

--- a/src/denormalize/cache.js
+++ b/src/denormalize/cache.js
@@ -1,0 +1,67 @@
+import get from 'lodash.get'
+import map from 'lodash.map'
+
+export const makeKey = (type, id) => `${type}:${id}`
+
+class DenormalizationCache {
+    denormalized = {}
+    manifests = {}
+    entities = {}
+
+    initializeManifest = ref => {
+        const { type, id } = ref
+        const key = makeKey(type, id)
+        return { [key]: ref }
+    }
+
+    addDenormalized = (type, id, data) => {
+        const key = makeKey(type, id)
+        this.denormalized[key] = data
+    }
+
+    addEntity = entity => {
+        const entityKey = makeKey(entity.type, entity.id)
+        this.entities[entityKey] = entity
+    }
+
+    addManifest = (entity, manifest) => {
+        const entityKey = makeKey(entity.type, entity.id)
+        this.manifests[entityKey] = this.manifests[entityKey] || {}
+
+        map(manifest, relatedRef => {
+            const relationshipKey = makeKey(relatedRef.type, relatedRef.id)
+            this.manifests[entityKey][relationshipKey] = relatedRef
+        })
+    }
+
+    getEntity = (type, id) => {
+        const key = makeKey(type, id)
+        return this.entities[key]
+    }
+
+    getManifest = (type, id) => {
+        const key = makeKey(type, id)
+        return this.manifests[key]
+    }
+
+    getDenormalized = (type, id) => {
+        const key = makeKey(type, id)
+        return this.denormalized[key]
+    }
+
+    hasDataChanged = (ref, entityStore) => {
+        const manifest = this.getManifest(ref.type, ref.id) || {}
+        const toCheck = [ref].concat(Object.values(manifest))
+
+        const changed = toCheck.reduce((memo, { type, id }) => {
+            const hasChanged =
+                this.getEntity(type, id) !== get(entityStore, [type, id])
+            return hasChanged || memo
+        }, false)
+
+        return changed
+    }
+}
+
+const denormalizationCache = new DenormalizationCache()
+export default denormalizationCache

--- a/src/denormalize/denormalize.test.js
+++ b/src/denormalize/denormalize.test.js
@@ -1,0 +1,441 @@
+import {
+    EntityStoreManager,
+    makeUserEntity,
+    makeFriendEntity,
+    makeFriendsEntity,
+} from './test.helpers'
+import denormalize from './index'
+import cache, { makeKey } from './cache'
+
+describe('nion/denormalize', () => {
+    describe('simple denormalization', () => {
+        it('an empty ref returns an empty array', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const ref = { entities: [] }
+            const object = denormalize(ref, entityStoreManager.store)
+            expect(object.length).toEqual(0)
+        })
+
+        it('an undefined ref returns undefined', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const ref = { entities: [undefined] }
+            const [object] = denormalize(ref, entityStoreManager.store)
+            expect(object).toEqual(undefined)
+        })
+
+        it('simple entity with no relationships is denormalized', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            entityStoreManager.addEntity(userEntity)
+
+            const { type, id } = userEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+
+            expect(object.type).toEqual(userEntity.type)
+            expect(object.id).toEqual(userEntity.id)
+            expect(object.name).toEqual(userEntity.attributes.name)
+        })
+
+        it('A simple entity with a relationship is denormalized', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const friendEntity = makeFriendEntity(userEntity.id)
+
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(friendEntity)
+
+            const { type, id } = friendEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+
+            expect(object.type).toEqual(friendEntity.type)
+            expect(object.id).toEqual(friendEntity.id)
+            expect(object.name).toEqual(friendEntity.attributes.name)
+            expect(object.friend.type).toEqual(userEntity.type)
+            expect(object.friend.id).toEqual(userEntity.id)
+            expect(object.friend.name).toEqual(userEntity.attributes.name)
+        })
+
+        it('A simple entity with plural relationships is denormalized', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const userEntity2 = makeUserEntity()
+            const friendsEntity = makeFriendsEntity([
+                userEntity.id,
+                userEntity2.id,
+            ])
+
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(userEntity2)
+            entityStoreManager.addEntity(friendsEntity)
+
+            const { type, id } = friendsEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+
+            expect(object.type).toEqual(friendsEntity.type)
+            expect(object.id).toEqual(friendsEntity.id)
+            expect(object.name).toEqual(friendsEntity.attributes.name)
+
+            expect(object.friends[0].type).toEqual(userEntity.type)
+            expect(object.friends[0].id).toEqual(userEntity.id)
+            expect(object.friends[0].name).toEqual(userEntity.attributes.name)
+
+            expect(object.friends[1].type).toEqual(userEntity2.type)
+            expect(object.friends[1].id).toEqual(userEntity2.id)
+            expect(object.friends[1].name).toEqual(userEntity2.attributes.name)
+        })
+    })
+
+    describe('denormalization caching', () => {
+        it('Denormalizing adds the immutable entity to the cache', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const entity = entityStoreManager.addEntity(userEntity)
+
+            const { type, id } = userEntity
+            const ref = { entities: [{ type, id }] }
+
+            denormalize(ref, entityStoreManager.store)
+            const cachedEntity = cache.getEntity(type, id)
+            expect(entity).toEqual(cachedEntity)
+        })
+
+        it('Denormalizing adds the immutable object to the cache', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            entityStoreManager.addEntity(userEntity)
+
+            const { type, id } = userEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+            const cachedObject = cache.getDenormalized(type, id)
+            expect(object).toEqual(cachedObject)
+        })
+
+        it('Denormalizing a ref with relationships adds manifest to the cache', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const friendEntity = makeFriendEntity(userEntity.id)
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(friendEntity)
+
+            const { type, id } = friendEntity
+            const ref = { entities: [{ type, id }] }
+
+            denormalize(ref, entityStoreManager.store)
+
+            const manifest = cache.getManifest(type, id)
+            expect(Object.keys(manifest)).toHaveLength(2)
+            const userKey = makeKey(userEntity.type, userEntity.id)
+            const friendKey = makeKey(friendEntity.type, friendEntity.id)
+            expect(manifest).toHaveProperty(userKey)
+            expect(manifest).toHaveProperty(friendKey)
+        })
+
+        it('If entities in the manifest have not changed, it returns the cached object', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const friendEntity = makeFriendEntity(userEntity.id)
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(friendEntity)
+
+            const { type, id } = friendEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [firstObject] = denormalize(ref, entityStoreManager.store)
+
+            // Add another, unrelated entity to the store
+            const userEntity2 = makeUserEntity()
+            entityStoreManager.addEntity(userEntity2)
+
+            // Fetch the denormalized object again - it should be cached
+            const [secondObject] = denormalize(ref, entityStoreManager.store)
+            expect(firstObject).toEqual(secondObject)
+        })
+
+        it('If entities in the manifest have changed, it returns a new denormalized object', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const friendEntity = makeFriendEntity(userEntity.id)
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(friendEntity)
+
+            const { type, id } = friendEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [firstObject] = denormalize(ref, entityStoreManager.store)
+
+            // Update the related entity, which should force a re-denormalization
+            entityStoreManager.updateEntity({
+                type: userEntity.type,
+                id: userEntity.id,
+                attributes: {
+                    favoriteColor: 'blue',
+                },
+            })
+
+            // Fetch the denormalized object again, it should be reconstructed
+            const [secondObject] = denormalize(ref, entityStoreManager.store)
+            expect(firstObject === secondObject).toEqual(false)
+            expect(secondObject.friend.favoriteColor).toEqual('blue')
+        })
+
+        it('If an entity is added to the relationship, it returns a new denormalized object', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const userEntity2 = makeUserEntity()
+
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(userEntity2)
+
+            const friendsEntity = makeFriendsEntity([
+                userEntity.id,
+                userEntity2.id,
+            ])
+
+            entityStoreManager.addEntity(friendsEntity)
+
+            const { type, id } = friendsEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [firstObject] = denormalize(ref, entityStoreManager.store)
+
+            // Now add a new entity to the store and add it as a relationship to the target object
+            const userEntity3 = makeUserEntity()
+            entityStoreManager.addEntity(userEntity3)
+
+            // Update the related entity, which should force a re-denormalization
+            entityStoreManager.updateEntity({
+                type: friendsEntity.type,
+                id: friendsEntity.id,
+                relationships: {
+                    friends: {
+                        data: [
+                            ...friendsEntity.relationships.friends.data,
+                            {
+                                type: userEntity3.type,
+                                id: userEntity3.id,
+                            },
+                        ],
+                    },
+                },
+            })
+
+            // Fetch the denormalized object again, it should be reconstructed, but the previously
+            // cached objects should remain the same
+            const [secondObject] = denormalize(ref, entityStoreManager.store)
+            expect(firstObject === secondObject).toEqual(false)
+            expect(secondObject.friends).toHaveLength(3)
+
+            expect(firstObject.friends[0]).toEqual(secondObject.friends[0])
+            expect(firstObject.friends[1]).toEqual(secondObject.friends[1])
+        })
+
+        it('If an entity is removed from the relationship, it returns a new denormalized object', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const userEntity2 = makeUserEntity()
+            const userEntity3 = makeUserEntity()
+
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(userEntity2)
+            entityStoreManager.addEntity(userEntity3)
+
+            const friendsEntity = makeFriendsEntity([
+                userEntity.id,
+                userEntity2.id,
+                userEntity3.id,
+            ])
+
+            entityStoreManager.addEntity(friendsEntity)
+
+            const { type, id } = friendsEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [firstObject] = denormalize(ref, entityStoreManager.store)
+
+            // Update the target entity, which should force a re-denormalization
+            const { data } = friendsEntity.relationships.friends
+            const nextData = data.slice(0, 2)
+            entityStoreManager.updateEntity({
+                type: friendsEntity.type,
+                id: friendsEntity.id,
+                relationships: {
+                    friends: {
+                        data: nextData,
+                    },
+                },
+            })
+
+            // Fetch the denormalized object again, it should be reconstructed, but the previously
+            // cached objects should remain the same
+            const [secondObject] = denormalize(ref, entityStoreManager.store)
+            expect(firstObject === secondObject).toEqual(false)
+            expect(secondObject.friends).toHaveLength(2)
+
+            expect(firstObject.friends[0]).toEqual(secondObject.friends[0])
+            expect(firstObject.friends[1]).toEqual(secondObject.friends[1])
+        })
+
+        it('If a related entity is deleted from the store, it returns a new denormalized object', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const userEntity2 = makeUserEntity()
+            const userEntity3 = makeUserEntity()
+
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(userEntity2)
+            entityStoreManager.addEntity(userEntity3)
+
+            const friendsEntity = makeFriendsEntity([
+                userEntity.id,
+                userEntity2.id,
+                userEntity3.id,
+            ])
+
+            entityStoreManager.addEntity(friendsEntity)
+
+            const { type, id } = friendsEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [firstObject] = denormalize(ref, entityStoreManager.store)
+
+            entityStoreManager.removeEntity(userEntity3)
+
+            // Fetch the denormalized object again, it should be reconstructed, but the previously
+            // cached objects should remain the same
+            const [secondObject] = denormalize(ref, entityStoreManager.store)
+            expect(firstObject === secondObject).toEqual(false)
+            expect(secondObject.friends).toHaveLength(3)
+
+            expect(secondObject.friends[0]).toEqual(firstObject.friends[0])
+            expect(secondObject.friends[1]).toEqual(firstObject.friends[1])
+            expect(secondObject.friends[2]).toEqual(undefined)
+        })
+
+        it('Handles updates to deeply nested entities', () => {
+            const entityStoreManager = new EntityStoreManager()
+
+            // Set up this relationship:
+            // friends -> [user, user2, friend -> user3]
+
+            const userEntity = makeUserEntity()
+            const userEntity2 = makeUserEntity()
+            const userEntity3 = makeUserEntity()
+            const friendEntity = makeFriendEntity(userEntity3.id)
+
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(userEntity2)
+            entityStoreManager.addEntity(userEntity3)
+            entityStoreManager.addEntity(friendEntity)
+
+            const friendsEntity = makeFriendsEntity([
+                userEntity.id,
+                userEntity2.id,
+                friendEntity.id,
+            ])
+
+            entityStoreManager.addEntity(friendsEntity)
+
+            const { type, id } = friendsEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [firstObject] = denormalize(ref, entityStoreManager.store)
+
+            entityStoreManager.updateEntity({
+                type: userEntity3.type,
+                id: userEntity3.id,
+                attributes: {
+                    favoriteColor: 'red',
+                },
+            })
+
+            // Fetch the denormalized object again, it should be reconstructed, but the previously
+            // cached objects should remain the same
+            const [secondObject] = denormalize(ref, entityStoreManager.store)
+            expect(firstObject === secondObject).toEqual(false)
+            expect(secondObject.friends).toHaveLength(3)
+
+            expect(secondObject.friends[0]).toEqual(firstObject.friends[0])
+            expect(secondObject.friends[1]).toEqual(firstObject.friends[1])
+            expect(secondObject.friends[2] === firstObject.friends[2]).toEqual(
+                false,
+            )
+            expect(secondObject.friends[2].friend.favoriteColor).toEqual('red')
+        })
+    })
+
+    describe('extra properties', () => {
+        it('adds an _exists property the denormalized data', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            entityStoreManager.addEntity(userEntity)
+
+            const { type, id } = userEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+            expect(object._exists).toEqual(true)
+        })
+
+        it('adds a _ref property of to the original ref being denormalized', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            entityStoreManager.addEntity(userEntity)
+
+            const { type, id } = userEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+            expect(object._ref).toMatchObject({ data: { type, id } })
+        })
+
+        it('adds a _ref property of a relationship being denormalized', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const friendEntity = makeFriendEntity(userEntity.id)
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(friendEntity)
+
+            const { type, id } = friendEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+
+            expect(object.friend._ref).toMatchObject({
+                data: {
+                    type: userEntity.type,
+                    id: userEntity.id,
+                },
+            })
+        })
+
+        it('adds a _ref property to a plural relationship being denormalized', () => {
+            const entityStoreManager = new EntityStoreManager()
+            const userEntity = makeUserEntity()
+            const friendsEntity = makeFriendsEntity([userEntity.id])
+            entityStoreManager.addEntity(userEntity)
+            entityStoreManager.addEntity(friendsEntity)
+
+            const { type, id } = friendsEntity
+            const ref = { entities: [{ type, id }] }
+
+            const [object] = denormalize(ref, entityStoreManager.store)
+
+            expect(object.friends._ref).toMatchObject({
+                data: [
+                    {
+                        type: userEntity.type,
+                        id: userEntity.id,
+                    },
+                ],
+            })
+        })
+    })
+})

--- a/src/denormalize/index.js
+++ b/src/denormalize/index.js
@@ -1,88 +1,151 @@
+import Immutable from 'seamless-immutable'
 import get from 'lodash.get'
-import set from 'lodash.set'
 import map from 'lodash.map'
-import merge from 'lodash.merge'
 import { camelize, camelizeKeys } from 'humps'
+import cache from './cache'
 
-export const defineEntityReference = (obj, value) =>
-    Object.defineProperty(obj, '_ref', { value })
+export default function denormalizeWithCache(reference, entityStore, dataKey) {
+    const refs = reference.entities
+    return refs.map(ref => {
+        const { denormalized } = denormalize(ref, entityStore)
+        return denormalized
+    })
+}
+
+class Data {
+    constructor(type, id, attributes) {
+        this.type = type
+        this.id = id
+        map(attributes, (value, key) => {
+            this[key] = value
+        })
+    }
+}
+Data.prototype._exists = true
+
+export const addEntityReference = (obj, value) => obj.set('_ref', value)
 
 export const getEntityReference = obj => get(obj, '_ref')
 
 export const hasEntityReference = obj => Boolean(getEntityReference(obj))
 
-export default function denormalize(
-    ref,
-    entities,
-    existingObjects = {},
-    returnAllObjects = false,
-) {
+// In order to optimize nion render performance, we want to both a) create immutable denormalized
+// objects (for simple equality comparison in our shouldUpdate / shouldRender logic) and b) cache
+// those denormalized objects to help reduce calls to the (somewhat) expensive denormalization step.
+// We achieve this by using a denormalization cache to do the following:
+//
+// - Each ref ({ type, id }) tuple will have a corresponding manifest of related refs ({ id, type })
+//   stored in the cache. This manifest includes a ref to every entity that composes the fully
+//   denormalized object, and we construct this list as we recursively denormalize an entity
+// - For each entity we denormalize, we keep a reference to the immutable entity object from the
+//   store. This will make it easy to compare the cached entity with the current entity in the
+//   passed in redux entityStore.
+// - This lets us easily check whether any of the entities that are related to a given entity
+//   (those that comprise the denormalized object) have changed by simple equality check of the
+//   cached vs incoming redux store entities.
+// - If the related entities have changed, we re-denormalize the object and store it, its entities,
+//   and its related refs in the cache
+// - If not, we simply fetch the already denormalized object from the cache
+//
+// Since all denormalized objects in the cache are immutable, we can very easily compare them
+// in downstream selectors, redux connect functions, or componentShouldUpdate methods to optimize
+// re-render performance
+function denormalize(ref, entityStore, existingObjects = {}) {
     if (!(ref && ref.type && ref.id)) {
-        return undefined
+        return { denormalized: undefined }
     }
 
     let { type, id } = ref
+    let manifest = cache.initializeManifest(ref)
+
+    // Check to see if the underlying data has changed for the ref, if not - we'll return the
+    // cached immutable denormalized version, otherwise we'll construct a new denormalized portion
+    // and update the related refs that are part of this ref's dependency tree
+    const hasDataChanged = cache.hasDataChanged(ref, entityStore)
+
+    if (!hasDataChanged) {
+        const denormalized = cache.getDenormalized(type, id)
+        return { denormalized, related: manifest }
+    }
 
     // Check the existing object to see if a reference to the denormalized object already exists,
     // if so, use the existing denormalized object
     const existingObject = get(existingObjects, [type, id])
     if (existingObject) {
-        return existingObject
+        return {
+            denormalized: existingObject,
+            related: manifest,
+        }
     }
 
-    const entity = get(entities, [type, id])
-
+    // Otherwise, fetch the entity from the entity store
+    const entity = get(entityStore, [type, id])
     if (entity === undefined) {
-        return undefined
+        return { denormalized: undefined }
     }
 
-    // Construct the new base denormalized object and add it to the existing map
-    const obj = {
-        id,
-        type,
-        ...camelizeKeys(entity.attributes),
-    }
-    // Explicitly set the type tracker as an object, because otherwise
-    // set({}, ['user', '123'], {}) => { user: [(empty x 122), {}] }
-    if (!get(existingObjects, type)) {
-        existingObjects[type] = {}
-    }
-    set(existingObjects, [type, id], obj)
+    // Construct the new base denormalized object and add it to the existing denormalized cache
+    const attributes = camelizeKeys(entity.attributes)
+    const data = new Data(type, id, attributes)
+    let obj = Immutable(data, {
+        prototype: Data.prototype,
+    })
 
+    existingObjects[type] = existingObjects[type] || {}
+    existingObjects[type][id] = obj
+
+    // Now map over the relationships, accruing a list of related refs that we check for changes
+    // against
     const relationships = get(entity, 'relationships', {})
+
     map(relationships, (relationship, key) => {
         const refOrRefs = relationship.data // The { id, type } pointers stored on 'data' key
         const camelizedKey = camelize(key)
 
+        // Define the next denormalized object or array of denormalized objects that we will set
+        // on the specific key. We'll also need to add a _ref property to this object so we can
+        // track the original information about the data
+        let toSet
+
         if (refOrRefs === null) {
-            obj[camelizedKey] = null
+            obj = obj.set(camelizedKey, null)
             return
         } else if (!Array.isArray(refOrRefs)) {
-            obj[camelizedKey] = denormalize(
+            const { denormalized, related } = denormalize(
                 refOrRefs,
-                entities,
+                entityStore,
                 existingObjects,
             )
+            toSet = denormalized
+            manifest = { ...manifest, ...related }
         } else {
-            obj[camelizedKey] = refOrRefs.map(relationshipRef => {
-                // eslint-disable-line
-                return denormalize(relationshipRef, entities, existingObjects)
+            toSet = refOrRefs.map(_ref => {
+                const { denormalized, related } = denormalize(
+                    _ref,
+                    entityStore,
+                    existingObjects,
+                )
+                manifest = { ...manifest, ...related }
+                return denormalized
             })
         }
 
-        // Establish a "_ref" property on the relationship object, that acts as a pointer to the
-        // original entity
-        if (obj[camelizedKey] && !hasEntityReference(obj[camelizedKey])) {
-            defineEntityReference(obj[camelizedKey], merge({}, relationship))
+        // Establish a "_ref" property on the object, that acts as a pointer to the original
+        // relationship
+        if (!hasEntityReference(toSet)) {
+            toSet = addEntityReference(toSet, relationship)
         }
+        obj = obj.set(camelizedKey, toSet)
     })
 
     // Establish a "_ref" property on the object, that acts as a pointer to the original entity
     if (!hasEntityReference(obj)) {
-        defineEntityReference(obj, { data: { id, type } })
+        obj = addEntityReference(obj, { data: { id, type } })
     }
-    if (returnAllObjects) {
-        return { obj, allObjects: existingObjects }
-    }
-    return obj
+
+    cache.addEntity(entity)
+    cache.addManifest(entity, manifest)
+    cache.addDenormalized(type, id, obj)
+
+    return { denormalized: obj, related: manifest }
 }

--- a/src/denormalize/test.helpers.js
+++ b/src/denormalize/test.helpers.js
@@ -1,0 +1,90 @@
+import Immutable from 'seamless-immutable'
+
+let _id = 1
+const generateId = () => {
+    return String(_id++)
+}
+
+export class EntityStoreManager {
+    store = Immutable({})
+
+    addEntity = ({ type, id, ...rest }) => {
+        this.store = this.store.merge(
+            {
+                [type]: {
+                    [id]: {
+                        type,
+                        id,
+                        ...rest,
+                    },
+                },
+            },
+            { deep: true },
+        )
+        return this.store[type][id]
+    }
+
+    updateEntity = (...args) => {
+        this.addEntity(...args)
+    }
+
+    removeEntity = ({ type, id }) => {
+        this.store = this.store.merge(
+            {
+                [type]: {
+                    [id]: undefined,
+                },
+            },
+            { deep: true },
+        )
+    }
+}
+
+export const makeUserEntity = () => {
+    const id = generateId()
+    return {
+        type: 'user',
+        id,
+        attributes: {
+            name: `Test User ${id}`,
+        },
+    }
+}
+
+export const makeFriendEntity = friendId => {
+    const id = generateId()
+    return {
+        type: 'user',
+        id,
+        attributes: {
+            name: `Friend User ${id}`,
+        },
+        relationships: {
+            friend: {
+                data: {
+                    type: 'user',
+                    id: friendId,
+                },
+            },
+        },
+    }
+}
+
+export const makeFriendsEntity = friendIds => {
+    const id = generateId()
+    return {
+        type: 'user',
+        id,
+        attributes: {
+            name: `Friend User ${id}`,
+        },
+        relationships: {
+            friends: {
+                data: friendIds.map(friendId => ({
+                    type: 'user',
+                    id: friendId,
+                })),
+            },
+        },
+    }
+}

--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -1,5 +1,5 @@
+import Immutable from 'seamless-immutable'
 import get from 'lodash.get'
-import map from 'lodash.map'
 
 import {
     NION_API_SUCCESS,
@@ -7,7 +7,7 @@ import {
     UPDATE_ENTITY,
 } from '../actions/types'
 
-const initialState = {}
+const initialState = Immutable({})
 
 // The core reducer for maintaining a normalized entity store of entities that are fetched / updated
 // between different JSON API actions
@@ -15,67 +15,34 @@ const entitiesReducer = (state = initialState, action) => {
     switch (action.type) {
         case NION_API_SUCCESS:
         case NION_API_BOOTSTRAP: {
-            const newState = {
-                ...state,
-            }
-
             const storeFragment = get(
                 action,
                 'payload.responseData.storeFragment',
                 {},
             )
 
-            map(storeFragment, (entities, type) => {
-                newState[type] = {
-                    ...get(newState, type, {}),
-                }
-
-                map(entities, (entity, id) => {
-                    newState[type][id] = {
-                        type,
-                        id,
-                        attributes: {
-                            ...get(newState[type][id], 'attributes', {}),
-                            ...get(entity, 'attributes', {}),
-                        },
-                        relationships: {
-                            ...get(newState[type][id], 'relationships', {}),
-                            ...get(entity, 'relationships', {}),
-                        },
-                    }
-                })
-            })
-
+            let nextState = state.merge(storeFragment, { deep: true })
+            // Handle deletion
             const refToDelete = get(action, 'meta.refToDelete')
             if (
                 refToDelete &&
                 refToDelete.id !== undefined &&
                 refToDelete.type
             ) {
-                delete newState[refToDelete.type][refToDelete.id]
+                const { type, id } = refToDelete
+                nextState = nextState.without([type, id])
             }
-            return newState
+            return nextState
         }
         case UPDATE_ENTITY: {
             const { type, id, attributes } = action.payload
             const entity = state[type][id]
-            const newEntity = {
-                ...entity,
-                attributes: {
-                    ...entity.attributes,
-                    ...attributes,
-                },
+            const newAttributes = {
+                ...entity.attributes,
+                ...attributes,
             }
 
-            const newState = {
-                ...state,
-                [type]: {
-                    ...state[type],
-                    [id]: newEntity,
-                },
-            }
-
-            return newState
+            return state.setIn([type, id, 'attributes'], newAttributes)
         }
         default:
             return state

--- a/src/reducers/references.test.js
+++ b/src/reducers/references.test.js
@@ -13,7 +13,7 @@ class Reducer {
 }
 
 describe('nion: reducers', () => {
-    describe('requests reducer', () => {
+    describe('references reducer', () => {
         it('should return the initial state', () => {
             const reducer = new Reducer()
             reducer.applyAction({})
@@ -166,6 +166,52 @@ describe('nion: reducers', () => {
             const user = get(reducer.state, [dataKey, 'entities', 0])
             expect(user.type).toEqual('user')
             expect(user.id).toEqual(456)
+        })
+
+        it('filters out refsToDelete from all refs', () => {
+            const reducer = new Reducer()
+
+            const initializationActions = [
+                makeAction(types.INITIALIZE_DATAKEY, 'userGroupA', {
+                    ref: {
+                        entities: [
+                            { type: 'user', id: 123 },
+                            { type: 'user', id: 456 },
+                        ],
+                    },
+                }),
+                makeAction(types.INITIALIZE_DATAKEY, 'userGroupB', {
+                    ref: {
+                        entities: [
+                            { type: 'user', id: 123 },
+                            { type: 'user', id: 789 },
+                        ],
+                    },
+                }),
+            ]
+            reducer.applyAction(initializationActions[0])
+            reducer.applyAction(initializationActions[1])
+
+            const deleteAction = makeAction(
+                types.NION_API_SUCCESS,
+                'someDataKey',
+                {
+                    refToDelete: { type: 'user', id: 123 },
+                },
+            )
+            reducer.applyAction(deleteAction)
+
+            const userGroupARef = get(reducer.state, 'userGroupA')
+            expect(userGroupARef.entities.length).toEqual(1)
+            const remaingingUserA = userGroupARef.entities[0]
+            expect(remaingingUserA.type).toEqual('user')
+            expect(remaingingUserA.id).toEqual(456)
+
+            const userGroupBRef = get(reducer.state, 'userGroupB')
+            expect(userGroupBRef.entities.length).toEqual(1)
+            const remaingingUserB = userGroupBRef.entities[0]
+            expect(remaingingUserB.type).toEqual('user')
+            expect(remaingingUserB.id).toEqual(789)
         })
     })
 })

--- a/src/reducers/requests.js
+++ b/src/reducers/requests.js
@@ -1,3 +1,4 @@
+import Immutable from 'seamless-immutable'
 import get from 'lodash.get'
 
 import {
@@ -6,49 +7,55 @@ import {
     NION_API_FAILURE,
 } from '../actions/types'
 
-const initialState = {}
+const initialState = Immutable({})
 
 const requestsReducer = (state = initialState, action) => {
     const existing = get(state, 'action.meta.dataKey')
 
     switch (action.type) {
         case NION_API_REQUEST:
-            return {
-                ...state,
-                [action.meta.dataKey]: {
-                    ...existing,
-                    status: 'pending',
-                    isLoading: true,
-                    pending: action.meta.method,
+            return state.merge(
+                {
+                    [action.meta.dataKey]: {
+                        ...existing,
+                        status: 'pending',
+                        isLoading: true,
+                        pending: action.meta.method,
+                    },
                 },
-            }
+                { deep: true },
+            )
         case NION_API_SUCCESS:
-            return {
-                ...state,
-                [action.meta.dataKey]: {
-                    ...existing,
-                    status: 'success',
-                    fetchedAt: action.meta.fetchedAt,
-                    isError: false,
-                    isLoaded: true,
-                    isLoading: false,
+            return state.merge(
+                {
+                    [action.meta.dataKey]: {
+                        ...existing,
+                        status: 'success',
+                        fetchedAt: action.meta.fetchedAt,
+                        isError: false,
+                        isLoaded: true,
+                        isLoading: false,
+                    },
                 },
-            }
+                { deep: true },
+            )
         case NION_API_FAILURE:
-            return {
-                ...state,
-                [action.meta.dataKey]: {
-                    ...existing,
-                    status: 'error',
-                    name: action.payload.name,
-                    errors: action.payload.errors,
-                    fetchedAt: action.meta.fetchedAt,
-                    isError: true,
-                    isLoaded: false,
-                    isLoading: false,
-                    pending: undefined,
+            return state.merge(
+                {
+                    [action.meta.dataKey]: {
+                        ...existing,
+                        status: 'error',
+                        name: action.payload.name,
+                        errors: action.payload.errors,
+                        fetchedAt: action.meta.fetchedAt,
+                        isError: true,
+                        isLoaded: false,
+                        isLoading: false,
+                        pending: undefined,
+                    },
                 },
-            }
+                { deep: true },
+            )
         default:
             return state
     }

--- a/src/reducers/requests.test.js
+++ b/src/reducers/requests.test.js
@@ -38,14 +38,15 @@ describe('nion: reducers', () => {
             const reducer = new Reducer()
             const dataKey = 'currentUser'
 
-            const rightThisSecond = Date.now()
             const action = makeAction(types.NION_API_SUCCESS, dataKey, {
                 method: 'GET',
             })
             reducer.applyAction(action)
             const request = get(reducer.state, dataKey)
             expect(request.status).toEqual('success')
-            expect(request.fetchedAt).toEqual(rightThisSecond)
+
+            const timeDiff = Math.abs(request.fetchedAt - Date.now())
+            expect(timeDiff).toBeLessThan(3)
             expect(request.isError).toEqual(false)
             expect(request.isLoaded).toEqual(true)
             expect(request.isLoading).toEqual(false)
@@ -58,7 +59,6 @@ describe('nion: reducers', () => {
             const errorName = 'Oh Snap!'
             const errors = 'Something went wrong'
 
-            const rightThisSecond = Date.now()
             const action = makeAction(types.NION_API_FAILURE, dataKey, {
                 method: 'GET',
                 errors,
@@ -69,7 +69,8 @@ describe('nion: reducers', () => {
             expect(request.status).toEqual('error')
             expect(request.name).toEqual(errorName)
             expect(request.errors).toEqual(errors)
-            expect(request.fetchedAt).toEqual(rightThisSecond)
+            const timeDiff = Math.abs(request.fetchedAt - Date.now())
+            expect(timeDiff).toBeLessThan(3)
             expect(request.isError).toEqual(true)
             expect(request.isLoaded).toEqual(false)
             expect(request.isLoading).toEqual(false)

--- a/src/utilities/shallow-equal.js
+++ b/src/utilities/shallow-equal.js
@@ -1,0 +1,41 @@
+// shallow equal from fbjs
+// https://github.com/reactjs/react-redux/blob/master/src/utils/shallowEqual.js
+// modified to ignore the "nion" prop
+
+const hasOwn = Object.prototype.hasOwnProperty
+
+function is(x, y) {
+    if (x === y) {
+        return x !== 0 || y !== 0 || 1 / x === 1 / y
+    } else {
+        return x !== x && y !== y
+    }
+}
+
+export default function shallowEqual(objA, objB) {
+    if (is(objA, objB)) return true
+
+    if (
+        typeof objA !== 'object' ||
+        objA === null ||
+        typeof objB !== 'object' ||
+        objB === null
+    ) {
+        return false
+    }
+
+    const keysA = Object.keys(objA)
+    const keysB = Object.keys(objB)
+
+    if (keysA.length !== keysB.length) return false
+
+    for (let i = 0; i < keysA.length; i++) {
+        const key = keysA[i]
+
+        if (!hasOwn.call(objB, key) || !is(objA[key], objB[key])) {
+            return false
+        }
+    }
+
+    return true
+}

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -352,6 +352,7 @@ describe('nion : integration tests', () => {
 
             test = getProp()
             expect(test.request.status).toEqual('success')
+
             expect(exists(test)).toEqual(false)
         })
 


### PR DESCRIPTION
This PR is yuuuuuugggeeee, and I think I'd like to *try* to break it up (it's been a bit tough to do it so far, but everything is working test / sandbox wise). On a high level, this PR does two things:
1) Implements a denormalization caching / render optimization strategy centered around using immutable data reducers
1) Reorganizes a bunch of internal APIs to make them a bit more robust and sensible

Here's a bit more detail about those two pieces:

### denormalization cache / performance optimizations
In order to optimize nion render performance, we want to both a) create immutable denormalized
objects (for simple equality comparison in our shouldUpdate / shouldRender logic) and b) cache
those denormalized objects to help reduce calls to the (somewhat) expensive denormalization step.
We achieve this by using a denormalization cache to do the following:

- Each ref ({ type, id }) tuple will have a corresponding dict of related refs ({ id, type })
  stored in the cache. These related refs include every entity that composes the fully
  denormalized object, and we construct this list as we recursively denormalize an entity
- For each entity we denormalize, we keep a reference to the immutable entity object from the
  store. This will make it easy to compare the cached entity with the current entity in the
  passed in redux entityStore.
- This lets us easily check whether any of the entities that are related to a given entity
  (those that comprise the denormalized object) have changed by simple equality check of the
  cached vs incoming redux store entities.
- If the related entities have changed, we re-denormalize the object and store it, its entities,
  and its related refs in the cache
- If not, we simply fetch the already denormalized object from the cache

Since all denormalized objects in the cache are immutable, we can very easily compare them
in downstream selectors, redux connect functions, or componentShouldUpdate methods to optimize
re-render performance

### internal API audit
The biggest change is in how we handle the results of selecting data from the stores - we used to splat out the denormalized object from `selectData` and add extra props to it - this is impractical for a number of reasons and is probably not what we want to do moving forward. This PR maintains four internal props on each dataKey, `data` (the result of the denormalization), `requests`, `actions`, and `extra` (any extra props such as `meta` and `links` that wind up on the `references` reducer). Since these props are namespaced, we can do a lot more sensible tracking of them throughout the decorator as well as do really fast === checking in our `shouldRerender` function... pretty cool stuff! We currently splat out the contents of `data` in the `finalProcessProps` function for passing into the decorated component, but this should be made optional (for legacy reasons) and, in a better world, moved away from completely, since the practice of passing in injected data under a namespaced key (ala reform.model and mallard.value) seems like best practice.
