### PR TITLE
Fix circleCI test file search blob to include /test/ dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             - run:
                 name: Test
                 command: |
-                    TESTFILES=$(circleci tests glob "src/**/{*.,}test.js" "app/**/__tests__/*.js" | circleci tests split --split-by=timings)
+                    TESTFILES=$(circleci tests glob "src/**/{*.,}test.js" "test/**/{*.,}test.js" | circleci tests split --split-by=timings)
                     JEST_JUNIT_OUTPUT="./test-artifacts/test-reports/junit-jest.xml" npm run test -- --runInBand ${TESTFILES}
 
             - store_test_results:


### PR DESCRIPTION
e.g. `integration.test.js` is not being run on circle, and it's been failing since https://github.com/Patreon/nion/pull/39

(but no one noticed because I suppose no one runs tests locally, CircleCI in nion didn't catch it, and we hadn't bumped the nion version in `patreon_react_features` since Sept 22)