### PR TITLE
safeguard cached entity graph reference building

### DIFF
--- a/lib/denormalize/index.js
+++ b/lib/denormalize/index.js
@@ -84,7 +84,7 @@ function getGenericRefData(ref) {
 }
 
 var addEntityReference = exports.addEntityReference = function addEntityReference(obj, value) {
-    return obj.set('_ref', value);
+    return obj && obj.set('_ref', value);
 };
 
 var getEntityReference = exports.getEntityReference = function getEntityReference(obj) {

--- a/src/denormalize/index.js
+++ b/src/denormalize/index.js
@@ -45,7 +45,9 @@ export function getGenericRefData(ref) {
     return genericData
 }
 
-export const addEntityReference = (obj, value) => obj.set('_ref', value)
+export const addEntityReference = (obj, value) => {
+    return obj && obj.set('_ref', value)
+}
 
 export const getEntityReference = obj => get(obj, '_ref')
 


### PR DESCRIPTION
ran into a scenario where a entity model had a `undefined` ID which is crazy..., this caused nion denormalization to bork completely. we gotta rethink orphaned entities like this

![screen shot 2017-09-30 at 11 09 13 pm](https://user-images.githubusercontent.com/680279/31052260-74164f80-a634-11e7-9f57-b96a99bbd62c.png)

