### PR TITLE
Fix selection of generic data (hack)

### DIFF
--- a/lib/denormalize/index.js
+++ b/lib/denormalize/index.js
@@ -72,14 +72,19 @@ function denormalizeWithCache(reference, entityStore, dataKey) {
     });
 }
 
+var makeGenericData = function makeGenericData(obj) {
+    var genericData = (0, _seamlessImmutable2.default)(new GenericData(obj), {
+        prototype: GenericData.prototype
+    });
+    return genericData;
+};
+
 function getGenericRefData(ref) {
     if (ref === null || ref === undefined) {
         return null;
     }
 
-    var genericData = (0, _seamlessImmutable2.default)(new GenericData(ref), {
-        prototype: GenericData.prototype
-    });
+    var genericData = ref instanceof Array ? ref.map(makeGenericData) : makeGenericData(ref);
     return genericData;
 }
 

--- a/src/denormalize/index.js
+++ b/src/denormalize/index.js
@@ -34,14 +34,20 @@ export default function denormalizeWithCache(reference, entityStore, dataKey) {
     })
 }
 
+const makeGenericData = obj => {
+    const genericData = Immutable(new GenericData(obj), {
+        prototype: GenericData.prototype,
+    })
+    return genericData
+}
+
 export function getGenericRefData(ref) {
     if (ref === null || ref === undefined) {
         return null
     }
 
-    const genericData = Immutable(new GenericData(ref), {
-        prototype: GenericData.prototype,
-    })
+    const genericData =
+        ref instanceof Array ? ref.map(makeGenericData) : makeGenericData(ref)
     return genericData
 }
 


### PR DESCRIPTION
After some changes to our immutable data selection caused errors with generic data, we introduced some more changes to the selection that introduced other problems. The real fix here is to get rid of the `exists` function by removing the ability to splat out onto the nion dataProp... this is a temporary fix while we adjust the react code, and then we'll make a stronger move to fix generic (non-normalized) data once and for all