### PR TITLE
Send reference-shaped object to denormalizeWithCache

### DIFF
--- a/lib/selectors/index.js
+++ b/lib/selectors/index.js
@@ -160,7 +160,10 @@ var selectResource = exports.selectResource = function selectResource(keyOrKeys)
 var selectData = exports.selectData = function selectData(key, defaultValue) {
     // If we pass in an object of { type, id } signature, denormalize the corresponding entity
     if ((typeof key === 'undefined' ? 'undefined' : (0, _typeof3.default)(key)) === 'object' && key.type && key.id !== undefined) {
-        var entityRef = key;
+        var entityRef = {
+            entities: [{ type: key.type, id: key.id }]
+        };
+
         return (0, _reselect.createSelector)(selectEntities, function (entityStore) {
             return (0, _denormalize2.default)(entityRef, entityStore);
         });

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -108,7 +108,10 @@ export const selectResource = keyOrKeys => {
 export const selectData = (key, defaultValue) => {
     // If we pass in an object of { type, id } signature, denormalize the corresponding entity
     if (typeof key === 'object' && key.type && key.id !== undefined) {
-        const entityRef = key
+        const entityRef = {
+            entities: [{ type: key.type, id: key.id }],
+        }
+
         return createSelector(selectEntities, entityStore =>
             denormalizeWithCache(entityRef, entityStore),
         )


### PR DESCRIPTION
`selectData` has a special case for `{ type, id }` keys in which it attempts to return a denormalized entity; this change makes sure that the object passed to `denormalizeWithCache` in that case is shaped as that function expects.

[Related bug](https://app.asana.com/0/15342483836751/454757009385289/f)