### PR TITLE
use latest version of isomorphic-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4052,7 +4052,7 @@
             }
         },
         "isomorphic-fetch": {
-            "version": "github:patreon/isomorphic-fetch#e4f90061be5fabed8fde118b04585478bfe185b2",
+            "version": "github:patreon/isomorphic-fetch#32ca40ad8a03c192f2f41217a674f8e5a2a35280",
             "requires": {
                 "node-fetch": "1.7.3",
                 "whatwg-fetch": "2.0.3"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
         "deep-equal": "^1.0.1",
         "humps": "^2.0.1",
         "is-equal-shallow": "^0.1.3",
-        "isomorphic-fetch":
-            "github:patreon/isomorphic-fetch#e4f90061be5fabed8fde118b04585478bfe185b2",
+        "isomorphic-fetch": "github:patreon/isomorphic-fetch#32ca40ad8a03c192f2f41217a674f8e5a2a35280",
         "lodash.difference": "^4.5.0",
         "lodash.every": "^4.6.0",
         "lodash.get": "^4.4.2",
@@ -41,8 +40,7 @@
         "prebuild:dist": "rimraf dist/*",
         "prebuild:watch": "rimraf lib/*",
         "lint:all": "eslint . --ext=js,jsx",
-        "lint":
-            "git diff --name-only master... | grep -E '\\.jsx?$' | xargs eslint",
+        "lint": "git diff --name-only master... | grep -E '\\.jsx?$' | xargs eslint",
         "test": "NODE_ENV=test jest"
     },
     "devDependencies": {
@@ -80,7 +78,12 @@
         "automock": false,
         "verbose": true,
         "setupTestFrameworkScriptFile": "./test/setup.js",
-        "moduleFileExtensions": ["js", "jsx"],
-        "collectCoverageFrom": ["src/**/*.js"]
+        "moduleFileExtensions": [
+            "js",
+            "jsx"
+        ],
+        "collectCoverageFrom": [
+            "src/**/*.js"
+        ]
     }
 }


### PR DESCRIPTION
to support LogRocket (sha referenced is not in master yet, but should be merged first)