### PR TITLE
Make `exists` function flattenSelectedData-aware

### DIFF
--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -481,11 +481,16 @@ export function exists(input = {}) {
         return input._exists
     }
 
-    const testExists = obj => !!(obj.id && obj.type) || input._exists || false
-
     if (input instanceof Array) {
         return true
     }
+
+    const refTest = obj =>
+        configuration.flattenSelectedData
+            ? !!(obj.data.id && obj.data.type)
+            : !!(obj.id && obj.type)
+
+    const testExists = obj => refTest(obj) || input._exists || false
 
     return testExists(input)
 }


### PR DESCRIPTION
Hey!

From what I can tell, nion's `exists` function seems to assume that the nion object it's testing is flat, which is problematic. I discovered this via [this PR from Xenia](https://github.com/Patreon/patreon_react_features/pull/5055) in which she unflatten's nion for the test store.

This change checks for the `flattenSelectedData` configuration setting and adjusts `exists`'s behavior to match the shape of the object it'll receive. Tests remain green, which is a good sign.