### PR TITLE
Remove variable that is always undefined

### DIFF
--- a/src/reducers/requests.js
+++ b/src/reducers/requests.js
@@ -10,14 +10,11 @@ import {
 const initialState = Immutable({})
 
 const requestsReducer = (state = initialState, action) => {
-    const existing = get(state, 'action.meta.dataKey')
-
     switch (action.type) {
         case NION_API_REQUEST:
             return state.merge(
                 {
                     [action.meta.dataKey]: {
-                        ...existing,
                         status: 'pending',
                         isLoading: true,
                         pending: action.meta.method,
@@ -29,7 +26,6 @@ const requestsReducer = (state = initialState, action) => {
             return state.merge(
                 {
                     [action.meta.dataKey]: {
-                        ...existing,
                         status: 'success',
                         fetchedAt: action.meta.fetchedAt,
                         isError: false,
@@ -43,7 +39,6 @@ const requestsReducer = (state = initialState, action) => {
             return state.merge(
                 {
                     [action.meta.dataKey]: {
-                        ...existing,
                         status: 'error',
                         name: action.payload.name,
                         errors: action.payload.errors,

--- a/src/reducers/requests.test.js
+++ b/src/reducers/requests.test.js
@@ -34,6 +34,27 @@ describe('nion: reducers', () => {
             expect(request.pending).toEqual('GET')
         })
 
+        it('handles a NION_API_REQUEST action after a success', () => {
+            const reducer = new Reducer()
+            const dataKey = 'currentUser'
+
+            const action = makeAction(types.NION_API_SUCCESS, dataKey, {
+                method: 'GET',
+            })
+            reducer.applyAction(action)
+
+            const requestAction = makeAction(types.NION_API_REQUEST, dataKey, {
+                method: 'GET',
+            })
+
+            reducer.applyAction(requestAction)
+
+            const request = get(reducer.state, dataKey)
+            expect(request.isError).toEqual(false)
+            expect(request.isLoaded).toEqual(true)
+            expect(request.isLoading).toEqual(true)
+        })
+
         it('handles a NION_API_SUCCESS action', () => {
             const reducer = new Reducer()
             const dataKey = 'currentUser'
@@ -52,7 +73,7 @@ describe('nion: reducers', () => {
             expect(request.isLoading).toEqual(false)
         })
 
-        it('handles a NION_API_SUCCESS action', () => {
+        it('handles a NION_API_FAILURE action', () => {
             const reducer = new Reducer()
             const dataKey = 'currentUser'
 


### PR DESCRIPTION
Existing will always be undefined. However, the code as we wrote it still behaved as we expected. So what I did was remove the variable, as it would always be undefined.
Add a test to confirm our code still works. 