### PR TITLE
adds `isProcessing` boolean and statusCode to the nion request object

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -45,12 +45,12 @@ var apiAction = function apiAction(method, dataKey, options) {
         var meta = (0, _extends3.default)({}, options.meta, {
             dataKey: dataKey,
             endpoint: endpoint,
-            method: method
+            method: method,
+            isProcessing: true
         });
 
         var _declaration$apiType = declaration.apiType,
             apiType = _declaration$apiType === undefined ? _api2.default.getDefaultApi() : _declaration$apiType;
-
 
         var parse = _api2.default.getParser(apiType);
         var ErrorClass = _api2.default.getErrorClass(apiType);
@@ -132,7 +132,9 @@ var apiAction = function apiAction(method, dataKey, options) {
                                 return dispatch({
                                     type: _types.NION_API_SUCCESS,
                                     meta: (0, _extends3.default)({}, meta, {
-                                        fetchedAt: Date.now()
+                                        fetchedAt: Date.now(),
+                                        statusCode: response.status,
+                                        isProcessing: response.status === 202 ? true : false
                                     }),
                                     payload: {
                                         requestType: apiType,
@@ -153,7 +155,9 @@ var apiAction = function apiAction(method, dataKey, options) {
                                 return dispatch({
                                     type: _types.NION_API_FAILURE,
                                     meta: (0, _extends3.default)({}, meta, {
-                                        fetchedAt: Date.now()
+                                        fetchedAt: Date.now(),
+                                        statusCode: _context.t0.status,
+                                        isProcessing: false
                                     }),
                                     payload: _context.t0
                                 });

--- a/lib/reducers/requests.js
+++ b/lib/reducers/requests.js
@@ -8,17 +8,9 @@ var _defineProperty2 = require('babel-runtime/helpers/defineProperty');
 
 var _defineProperty3 = _interopRequireDefault(_defineProperty2);
 
-var _extends2 = require('babel-runtime/helpers/extends');
-
-var _extends3 = _interopRequireDefault(_extends2);
-
 var _seamlessImmutable = require('seamless-immutable');
 
 var _seamlessImmutable2 = _interopRequireDefault(_seamlessImmutable);
-
-var _lodash = require('lodash.get');
-
-var _lodash2 = _interopRequireDefault(_lodash);
 
 var _types = require('../actions/types');
 
@@ -30,34 +22,38 @@ var requestsReducer = function requestsReducer() {
     var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
     var action = arguments[1];
 
-    var existing = (0, _lodash2.default)(state, 'action.meta.dataKey');
-
     switch (action.type) {
         case _types.NION_API_REQUEST:
-            return state.merge((0, _defineProperty3.default)({}, action.meta.dataKey, (0, _extends3.default)({}, existing, {
-                status: 'pending',
+            return state.merge((0, _defineProperty3.default)({}, action.meta.dataKey, {
                 isLoading: true,
-                pending: action.meta.method
-            })), { deep: true });
+                isProcessing: action.meta.isProcessing,
+                pending: action.meta.method,
+                status: 'pending',
+                statusCode: undefined
+            }), { deep: true });
         case _types.NION_API_SUCCESS:
-            return state.merge((0, _defineProperty3.default)({}, action.meta.dataKey, (0, _extends3.default)({}, existing, {
-                status: 'success',
+            return state.merge((0, _defineProperty3.default)({}, action.meta.dataKey, {
                 fetchedAt: action.meta.fetchedAt,
                 isError: false,
                 isLoaded: true,
-                isLoading: false
-            })), { deep: true });
+                isLoading: false,
+                isProcessing: action.meta.isProcessing,
+                status: 'success',
+                statusCode: action.meta.statusCode
+            }), { deep: true });
         case _types.NION_API_FAILURE:
-            return state.merge((0, _defineProperty3.default)({}, action.meta.dataKey, (0, _extends3.default)({}, existing, {
-                status: 'error',
-                name: action.payload.name,
+            return state.merge((0, _defineProperty3.default)({}, action.meta.dataKey, {
                 errors: action.payload.errors,
                 fetchedAt: action.meta.fetchedAt,
                 isError: true,
                 isLoaded: false,
                 isLoading: false,
-                pending: undefined
-            })), { deep: true });
+                isProcessing: action.meta.isProcessing,
+                name: action.payload.name,
+                pending: undefined,
+                status: 'error',
+                statusCode: action.meta.statusCode
+            }), { deep: true });
         default:
             return state;
     }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -18,10 +18,10 @@ const apiAction = (method, dataKey, options) => _dispatch => {
         dataKey,
         endpoint,
         method,
+        isProcessing: true,
     }
 
     const { apiType = ApiManager.getDefaultApi() } = declaration
-
     const parse = ApiManager.getParser(apiType)
     const ErrorClass = ApiManager.getErrorClass(apiType)
 
@@ -85,6 +85,8 @@ const apiAction = (method, dataKey, options) => _dispatch => {
                 meta: {
                     ...meta,
                     fetchedAt: Date.now(),
+                    statusCode: response.status,
+                    isProcessing: response.status === 202 ? true : false,
                 },
                 payload: {
                     requestType: apiType,
@@ -101,6 +103,8 @@ const apiAction = (method, dataKey, options) => _dispatch => {
                     meta: {
                         ...meta,
                         fetchedAt: Date.now(),
+                        statusCode: error.status,
+                        isProcessing: false,
                     },
                     payload: error,
                 })

--- a/src/reducers/requests.js
+++ b/src/reducers/requests.js
@@ -1,5 +1,4 @@
 import Immutable from 'seamless-immutable'
-import get from 'lodash.get'
 
 import {
     NION_API_REQUEST,
@@ -15,9 +14,11 @@ const requestsReducer = (state = initialState, action) => {
             return state.merge(
                 {
                     [action.meta.dataKey]: {
-                        status: 'pending',
                         isLoading: true,
+                        isProcessing: action.meta.isProcessing,
                         pending: action.meta.method,
+                        status: 'pending',
+                        statusCode: undefined,
                     },
                 },
                 { deep: true },
@@ -26,11 +27,13 @@ const requestsReducer = (state = initialState, action) => {
             return state.merge(
                 {
                     [action.meta.dataKey]: {
-                        status: 'success',
                         fetchedAt: action.meta.fetchedAt,
                         isError: false,
                         isLoaded: true,
                         isLoading: false,
+                        isProcessing: action.meta.isProcessing,
+                        status: 'success',
+                        statusCode: action.meta.statusCode,
                     },
                 },
                 { deep: true },
@@ -39,14 +42,16 @@ const requestsReducer = (state = initialState, action) => {
             return state.merge(
                 {
                     [action.meta.dataKey]: {
-                        status: 'error',
-                        name: action.payload.name,
                         errors: action.payload.errors,
                         fetchedAt: action.meta.fetchedAt,
                         isError: true,
                         isLoaded: false,
                         isLoading: false,
+                        isProcessing: action.meta.isProcessing,
+                        name: action.payload.name,
                         pending: undefined,
+                        status: 'error',
+                        statusCode: action.meta.statusCode,
                     },
                 },
                 { deep: true },

--- a/src/reducers/requests.test.js
+++ b/src/reducers/requests.test.js
@@ -26,12 +26,16 @@ describe('nion: reducers', () => {
 
             const action = makeAction(types.NION_API_REQUEST, dataKey, {
                 method: 'GET',
+                statusCode: undefined,
+                isProcessing: true,
             })
             reducer.applyAction(action)
             const request = get(reducer.state, dataKey)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
             expect(request.pending).toEqual('GET')
+            expect(request.isProcessing).toEqual(true)
+            expect(request.statusCode).toEqual(undefined)
         })
 
         it('handles a NION_API_REQUEST action after a success', () => {
@@ -40,6 +44,8 @@ describe('nion: reducers', () => {
 
             const action = makeAction(types.NION_API_SUCCESS, dataKey, {
                 method: 'GET',
+                statusCode: 200,
+                isProcessing: false,
             })
             reducer.applyAction(action)
 
@@ -53,6 +59,7 @@ describe('nion: reducers', () => {
             expect(request.isError).toEqual(false)
             expect(request.isLoaded).toEqual(true)
             expect(request.isLoading).toEqual(true)
+            expect(request.statusCode).toEqual(undefined)
         })
 
         it('handles a NION_API_SUCCESS action', () => {
@@ -61,6 +68,8 @@ describe('nion: reducers', () => {
 
             const action = makeAction(types.NION_API_SUCCESS, dataKey, {
                 method: 'GET',
+                statusCode: 200,
+                isProcessing: false,
             })
             reducer.applyAction(action)
             const request = get(reducer.state, dataKey)
@@ -71,6 +80,30 @@ describe('nion: reducers', () => {
             expect(request.isError).toEqual(false)
             expect(request.isLoaded).toEqual(true)
             expect(request.isLoading).toEqual(false)
+            expect(request.isProcessing).toEqual(false)
+            expect(request.statusCode).toEqual(200)
+        })
+
+        it('handles a NION_API_SUCCESS still processing action', () => {
+            const reducer = new Reducer()
+            const dataKey = 'currentUser'
+
+            const action = makeAction(types.NION_API_SUCCESS, dataKey, {
+                method: 'GET',
+                statusCode: 202,
+                isProcessing: true,
+            })
+            reducer.applyAction(action)
+            const request = get(reducer.state, dataKey)
+            expect(request.status).toEqual('success')
+
+            const timeDiff = Math.abs(request.fetchedAt - Date.now())
+            expect(timeDiff).toBeLessThan(3)
+            expect(request.isError).toEqual(false)
+            expect(request.isLoaded).toEqual(true)
+            expect(request.isLoading).toEqual(false)
+            expect(request.isProcessing).toEqual(true)
+            expect(request.statusCode).toEqual(202)
         })
 
         it('handles a NION_API_FAILURE action', () => {
@@ -84,6 +117,8 @@ describe('nion: reducers', () => {
                 method: 'GET',
                 errors,
                 name: errorName,
+                statusCode: 500,
+                isProcessing: false,
             })
             reducer.applyAction(action)
             const request = get(reducer.state, dataKey)
@@ -95,12 +130,18 @@ describe('nion: reducers', () => {
             expect(request.isError).toEqual(true)
             expect(request.isLoaded).toEqual(false)
             expect(request.isLoading).toEqual(false)
+            expect(request.isProcessing).toEqual(false)
             expect(request.pending).toEqual(undefined)
+            expect(request.statusCode).toEqual(500)
         })
     })
 })
 
-function makeAction(actionType, dataKey, { method, name, errors }) {
+function makeAction(
+    actionType,
+    dataKey,
+    { method, name, errors, statusCode, isProcessing },
+) {
     return {
         type: actionType,
         payload: {
@@ -111,6 +152,8 @@ function makeAction(actionType, dataKey, { method, name, errors }) {
             dataKey,
             method,
             fetchedAt: Date.now(),
+            statusCode,
+            isProcessing,
         },
     }
 }


### PR DESCRIPTION
We have a usage case now where an endpoint can return a 202 response to indicate the server is still processing. We now add `isProcessing` to the request object as well as pipe through the raw status code going forward.

Also added tests or upgraded existing tests to ensure this is being set properly.
![screen shot 2018-08-31 at 3 21 46 pm](https://user-images.githubusercontent.com/680279/44938135-e3b39500-ad31-11e8-876e-cc7cf78aedca.png)

Side note: i think the requests reducer is ripe for refactor, we should not be hard setting values in the reducer itself, and should either add an additional layer or have the actions layer dictate all of the request object values.
