### PR TITLE
no longer make fetch request on container init w/ param `fetchOnInit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3327,14 +3327,6 @@
                         }
                     }
                 },
-                "string_decoder": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
@@ -3343,6 +3335,14 @@
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
                         "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
                     }
                 },
                 "stringstream": {
@@ -5486,6 +5486,7 @@
             "integrity": "sha512-F6LLCAHriKyKQ9Ff03UKCjkXZoRBp281I42K42+VeHfjAXZ3TJdg3RccinzoCFV1kDxCedVm7AstIpb1Uf5UkQ==",
             "dev": true,
             "requires": {
+                "JSONStream": "1.3.1",
                 "abbrev": "1.1.0",
                 "ansi-regex": "3.0.0",
                 "ansicolors": "0.3.2",
@@ -5515,7 +5516,6 @@
                 "inherits": "2.0.3",
                 "ini": "1.3.4",
                 "init-package-json": "1.10.1",
-                "JSONStream": "1.3.1",
                 "lazy-property": "1.0.0",
                 "libnpx": "9.6.0",
                 "lockfile": "1.0.3",
@@ -5586,6 +5586,27 @@
                 "write-file-atomic": "2.1.0"
             },
             "dependencies": {
+                "JSONStream": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "jsonparse": "1.3.1",
+                        "through": "2.3.8"
+                    },
+                    "dependencies": {
+                        "jsonparse": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "through": {
+                            "version": "2.3.8",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
                 "abbrev": {
                     "version": "1.1.0",
                     "bundled": true,
@@ -5929,27 +5950,6 @@
                             "requires": {
                                 "read": "1.0.7"
                             }
-                        }
-                    }
-                },
-                "JSONStream": {
-                    "version": "1.3.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "jsonparse": "1.3.1",
-                        "through": "2.3.8"
-                    },
-                    "dependencies": {
-                        "jsonparse": {
-                            "version": "1.3.1",
-                            "bundled": true,
-                            "dev": true
-                        },
-                        "through": {
-                            "version": "2.3.8",
-                            "bundled": true,
-                            "dev": true
                         }
                     }
                 },
@@ -10059,15 +10059,6 @@
                 "tweetnacl": "0.14.5"
             }
         },
-        "string_decoder": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
         "string-length": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -10104,6 +10095,15 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
             }
         },
         "stringstream": {

--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -371,7 +371,7 @@ const nion = (declarations = {}, ...rest) => WrappedComponent => {
             this.initializeDataKeys(nextProps)
         }
 
-        initializeDataKeys(props) {
+        fetchOnMount(props) {
             const { nion } = props // eslint-disable-line no-shadow
 
             // We want to trigger a fetch when the props change and lead to the creation of a new
@@ -411,8 +411,8 @@ const nion = (declarations = {}, ...rest) => WrappedComponent => {
             })
         }
 
-        componentDidMount() {
-            const { nion } = this.props // eslint-disable-line no-shadow
+        initializeDataKeys(props) {
+            const { nion } = props // eslint-disable-line no-shadow
 
             // Iterate over the declarations provided to the component, deciding how to manage the
             // load state of each one
@@ -433,6 +433,10 @@ const nion = (declarations = {}, ...rest) => WrappedComponent => {
                     return nion._initializeDataKey(dataKey, initialRef)
                 }
             })
+        }
+
+        componentDidMount() {
+            this.fetchOnMount(this.props)
         }
 
         render() {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -170,10 +170,6 @@ describe('nion : integration tests', () => {
                     .find('Container')
                     .props().nion.test
 
-            let test = getProp()
-            expect(test.request.status).toEqual('pending')
-            expect(test.request.isLoading).toEqual(true)
-
             await P.delay(15) // Wait 15ms for the request reducer to update
 
             test = getProp()


### PR DESCRIPTION
**problem**
nion fires off requests on container initialization which does not respect react lifecycle methods. This is causing requests to happen during SSR which we do not want to do.

**solution**
we now instead attempt to fetch on `componentDidMount`