### PR TITLE
Bail out of caching entirely when data has meta

### DIFF
--- a/src/denormalize/cache.js
+++ b/src/denormalize/cache.js
@@ -50,6 +50,10 @@ class DenormalizationCache {
     }
 
     hasDataChanged = (ref, entityStore) => {
+        if (ref.meta !== undefined) {
+            return true
+        }
+
         const manifest = this.getManifest(ref.type, ref.id) || {}
         const toCheck = [ref].concat(Object.values(manifest))
 


### PR DESCRIPTION
Not sure if this can enact the re-denormalization that wasn't happened properly when some data's `meta` changes, as investigated by @liamdanger, but only one way to find out.