### PR TITLE
Add `extra` to useNion hook's returned tuple

### DIFF
--- a/src/hook/useNion.js
+++ b/src/hook/useNion.js
@@ -175,7 +175,7 @@ function useNion(declaration, deps = []) {
         nion.obj,
     ])
 
-    return [nion.obj, actions, nion.request]
+    return [nion.obj, actions, nion.request, nion.extra]
 }
 
 export default useNion

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,10 +97,12 @@ export interface HookDeclaration extends CommonDeclarationValues {
     fetchOnMount?: boolean
 }
 
+export type NionMeta = Record<'meta' | string, any>
+
 export function useNion<T>(
     declaration: string | HookDeclaration,
     dependencyArray?: any[],
-): [T | null, Actions<T>, NionRequest]
+): [T | null, Actions<T>, NionRequest, NionMeta]
 
 export interface ExpandedHOCDeclaration extends CommonDeclarationValues {
     dataKey?: string


### PR DESCRIPTION
👋 I'm running into situations where I need `extra` in order to use the `meta.pagination` properties on JSON API responses. This seems like it'll Just Work™️, since the `selectResourcesForKeys` selector we use to create this `nion` object already includes the `extra` key.