### PR TITLE
FECORE-1575, fix vulnerability by removing unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.0.0-4",
+    "version": "3.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -8228,16 +8228,6 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
             "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
-        },
-        "lodash.mapvalues": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
-        },
-        "lodash.merge": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-            "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
         },
         "lodash.omit": {
             "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
         "lodash.every": "^4.6.0",
         "lodash.get": "^4.4.2",
         "lodash.map": "^4.6.0",
-        "lodash.mapvalues": "^4.6.0",
-        "lodash.merge": "^4.6.0",
         "lodash.omit": "^4.5.0",
         "lodash.set": "^4.3.2",
         "lodash.union": "^4.6.0",


### PR DESCRIPTION
Before:
```
jmckenney at baobabhouse in ~/repos/nion (master)
$ npm audit --production

                       === npm audit security report ===

# Run  npm update lodash.merge --depth 1  to resolve 2 vulnerabilities
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash.merge                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ lodash.merge                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ lodash.merge                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1066                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash.merge                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ lodash.merge                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ lodash.merge                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1067                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 2 high severity vulnerabilities in 28 scanned packages
  run `npm audit fix` to fix 2 of them.

```

Confirm that this package is unused.
```
jmckenney at baobabhouse in ~/repos/nion (joe/FECORE-1575)
$ git grep -E 'import.*merge'

...crickets...
```

While cleaning that up, remove one other unused dependency
```
jmckenney at baobabhouse in ~/repos/nion (joe/FECORE-1575)
$ git grep -E 'import.*mapvalues'

...crickets...
```

After:
```
jmckenney at baobabhouse in ~/repos/nion (joe/FECORE-1575)
$ npm audit --production

                       === npm audit security report ===

found 0 vulnerabilities
 in 26 scanned packages
```