### PR TITLE
Fix: cycle detection branch pollution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "license": "MIT",
     "browser": "es/index.js",
     "main": "lib/index.js",

--- a/src/denormalize/cache.js
+++ b/src/denormalize/cache.js
@@ -53,13 +53,10 @@ class DenormalizationCache {
         const manifest = this.getManifest(ref.type, ref.id) || {}
         const toCheck = [ref].concat(Object.values(manifest))
 
-        const changed = toCheck.reduce((memo, { type, id }) => {
-            const hasChanged =
-                this.getEntity(type, id) !== get(entityStore, [type, id])
-            return hasChanged || memo
-        }, false)
-
-        return changed
+        return toCheck.some(
+            ({ type, id }) =>
+                this.getEntity(type, id) !== get(entityStore, [type, id]),
+        )
     }
 }
 


### PR DESCRIPTION
## Problem
If, in the entity store, there exists a graph that meets certain criteria, then some of the descendent resources after denormalization will be missing their relationships. The criteria that causes this to occur is:
* There exists a descendent node of the root node which has multiple paths from that root node to the descendent node
* There exists a cycle in the directed graph
(e.g., A->B->C->A and A->C->A. after denormalization, `A.C` will have no relationships present)

What happens is: when denormalizing, we avoid getting trapped in infinite recursion while denormalizing cycles (e.g., in the prior example, `A.B.C.A` intentionally has no relationships when denormalized). However, our algorithm for detecting and preventing these cases doesn't clean up after itself when switching edges (i.e., the A->B->C->A cycle detection impacts the outcome of the A->C->A case).

## Solution
Add a fix for a way in which our cycle prevention impacted sibling denormalization branches (and a test that proves it works). Specifically, we create an independent copy of our marked node set for each outgoing edge of a node.