### PR TITLE
adds `PUT` action and adds `appendKey` meta option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "license": "MIT",
     "browser": "es/index.js",
     "main": "lib/index.js",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -126,6 +126,10 @@ const postAction = (dataKey, options) => {
     return apiAction('POST', dataKey, options)
 }
 
+const putAction = (dataKey, options) => {
+    return apiAction('PUT', dataKey, options)
+}
+
 const patchAction = (dataKey, options) => {
     return apiAction('PATCH', dataKey, options)
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -170,8 +170,8 @@ const updateEntityAction = ({ type, id }, attributes) => {
 }
 
 export const get = getAction
-
 export const post = postAction
+export const put = putAction
 export const patch = patchAction
 export { deleteAction as delete }
 export const bootstrap = bootstrapAction
@@ -179,7 +179,7 @@ export const updateEntity = updateEntityAction
 
 export default {
     get,
-    putAction,
+    put,
     post,
     patch,
     delete: deleteAction,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -179,6 +179,7 @@ export const updateEntity = updateEntityAction
 
 export default {
     get,
+    putAction,
     post,
     patch,
     delete: deleteAction,

--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -180,7 +180,7 @@ const processDeclarations = (inputDeclarations, ...rest) => {
 
             dispatchProps[key]['PUT'] = (params, actionOptions = {}) => {
                 const endpoint = getUrl(declaration, params)
-                return nionActions.get(dataKey, {
+                return nionActions.put(dataKey, {
                     declaration,
                     endpoint,
                     meta: {

--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -152,6 +152,7 @@ const processDeclarations = (inputDeclarations, ...rest) => {
                     body,
                     meta: {
                         append: get(actionOptions, 'append'),
+                        appendKey: get(actionOptions, 'appendKey'),
                     },
                 })(dispatch)
             }
@@ -172,6 +173,19 @@ const processDeclarations = (inputDeclarations, ...rest) => {
                     endpoint,
                     meta: {
                         append: get(actionOptions, 'append'),
+                        appendKey: get(actionOptions, 'appendKey'),
+                    },
+                })(dispatch)
+            }
+
+            dispatchProps[key]['PUT'] = (params, actionOptions = {}) => {
+                const endpoint = getUrl(declaration, params)
+                return nionActions.get(dataKey, {
+                    declaration,
+                    endpoint,
+                    meta: {
+                        append: get(actionOptions, 'append'),
+                        appendKey: get(actionOptions, 'appendKey'),
                     },
                 })(dispatch)
             }

--- a/src/hook/useNion.js
+++ b/src/hook/useNion.js
@@ -43,6 +43,7 @@ function useNion(declaration, deps = []) {
                 endpoint,
                 meta: {
                     append: get(actionOptions, 'append'),
+                    appendKey: get(actionOptions, 'appendKey'),
                 },
             })(dispatch)
         },
@@ -59,6 +60,7 @@ function useNion(declaration, deps = []) {
                 body,
                 meta: {
                     append: get(actionOptions, 'append'),
+                    appendKey: get(actionOptions, 'appendKey'),
                 },
             })(dispatch)
         },

--- a/src/hook/useNion.js
+++ b/src/hook/useNion.js
@@ -67,6 +67,23 @@ function useNion(declaration, deps = []) {
         [coercedDeclaration, dispatch],
     )
 
+    const putResource = useCallback(
+        (body = {}, params, actionOptions) => {
+            const endpoint = getUrl(coercedDeclaration, params)
+
+            return nionActions.put(coercedDeclaration.dataKey, {
+                endpoint,
+                declaration: coercedDeclaration,
+                body,
+                meta: {
+                    append: get(actionOptions, 'append'),
+                    appendKey: get(actionOptions, 'appendKey'),
+                },
+            })(dispatch)
+        },
+        [coercedDeclaration, dispatch],
+    )
+
     const patchResource = useCallback(
         (body = {}, params) => {
             const endpoint = getUrl(coercedDeclaration, params)
@@ -137,6 +154,7 @@ function useNion(declaration, deps = []) {
     const actions = useMemo(
         () => ({
             get: getResources,
+            put: putResource,
             post: postResource,
             patch: patchResource,
             delete: deleteResource,
@@ -145,6 +163,7 @@ function useNion(declaration, deps = []) {
         }),
         [
             getResources,
+            putResource,
             postResource,
             patchResource,
             deleteResource,

--- a/src/reducers/references.js
+++ b/src/reducers/references.js
@@ -40,7 +40,7 @@ const refsReducer = (state = initialState, action) => {
         case NION_API_SUCCESS:
             if (
                 action.meta.appendKey &&
-                !action.payload.requestType !== 'jsonApi'
+                action.payload.requestType !== 'jsonApi'
             ) {
                 const appendKey = action.meta.appendKey
                 const previousEntities = get(

--- a/src/reducers/references.js
+++ b/src/reducers/references.js
@@ -38,9 +38,28 @@ const refsReducer = (state = initialState, action) => {
             return state
         case NION_API_BOOTSTRAP:
         case NION_API_SUCCESS:
-            // If the result of a paginated nextPage request, we're going to want to append the
-            // retrieved entities to the end of the current entities list
-            if (action.meta.isNextPage || action.meta.append) {
+            if (
+                action.meta.appendKey &&
+                !action.payload.requestType !== 'jsonApi'
+            ) {
+                const appendKey = action.meta.appendKey
+                const previousEntities = get(
+                    state[action.meta.dataKey],
+                    appendKey,
+                )
+                return state.merge(
+                    {
+                        [action.meta.dataKey]: {
+                            [appendKey]: previousEntities.concat(
+                                action.payload.responseData.entryRef,
+                            ),
+                        },
+                    },
+                    { deep: true },
+                )
+            } else if (action.meta.isNextPage || action.meta.append) {
+                // If the result of a paginated nextPage request, we're going to want to append the
+                // retrieved entities to the end of the current entities list
                 const nextPageRef = action.payload.responseData.entryRef
                 const oldEntities = get(
                     state[action.meta.dataKey],

--- a/src/reducers/references.test.js
+++ b/src/reducers/references.test.js
@@ -102,6 +102,29 @@ describe('nion: reducers', () => {
             expect(isCollection).toEqual(true)
         })
 
+        it('handles a NION_API_SUCCESS with meta.appendKey', () => {
+            const reducer = new Reducer()
+            const dataKey = 'messageKey'
+            const appendKey = 'messages'
+
+            const action = makeAction(types.NION_API_SUCCESS, dataKey, {
+                entryRef: {
+                    messages: [{ type: 'message', id: 123 }],
+                },
+            })
+            reducer.applyAction(action)
+
+            const nextAction = makeAction(types.NION_API_SUCCESS, dataKey, {
+                entryRef: [{ type: 'message', id: 456 }],
+                appendKey: appendKey,
+            })
+            reducer.applyAction(nextAction)
+
+            const newMessage = get(reducer.state[dataKey][appendKey], 1)
+            expect(newMessage.type).toEqual('message')
+            expect(newMessage.id).toEqual(456)
+        })
+
         it('adds links', () => {
             const reducer = new Reducer()
             const dataKey = 'users'
@@ -260,7 +283,7 @@ describe('nion: reducers', () => {
 function makeAction(
     actionType,
     dataKey,
-    { entryRef, ref, isNextPage, append, refToDelete },
+    { entryRef, ref, isNextPage, append, appendKey, refToDelete },
 ) {
     return {
         type: actionType,
@@ -275,6 +298,7 @@ function makeAction(
             dataKey,
             isNextPage,
             append,
+            appendKey,
             refToDelete,
         },
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,8 +27,13 @@ export interface NionRef {
     type: string
 }
 
+export interface GetActionOptions {
+    append?: boolean
+    appendKey?: string
+}
+
 export interface Actions<T> {
-    get(params?: any, actionOptions?: { append?: boolean, appendKey?: string }): Promise<T>
+    get(params?: any, actionOptions?: GetActionOptions): Promise<T>
     delete(params?: any): Promise<T>
     patch(body?: any, params?: any): Promise<T>
     post(body?: any, params?: any): Promise<T>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ export interface NionRef {
 }
 
 export interface Actions<T> {
-    get(params?: any, actionOptions?: { append?: boolean }): Promise<T>
+    get(params?: any, actionOptions?: { append?: boolean, appendKey?: string }): Promise<T>
     delete(params?: any): Promise<T>
     patch(body?: any, params?: any): Promise<T>
     post(body?: any, params?: any): Promise<T>


### PR DESCRIPTION
We are integrating with Sendbird and require 2 things

1) `PUT` action to mark messages as unread

2) ability to dynamically append to a JSON key (non JSON-API). This has become quite common where the nested list is within a payload object, this may be slightly brittle, but would also apply to things like algolia search.

