### PR TITLE
PX-1764 debug json SyntaxError

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,6 @@ export default function configureStore() {
 
 [Read more about configuring nion in the docs.](docs/configuration.md)
 
-## Developing in PRF
-
-1.  Make sure `nion` is a sibling to `patreon_react_features` in a `devx` synced folder
-1.  In `patreon_react_features` execute `npm run link:nion`
-1.  In `nion` execute `npm run build`
-1.  Restart react: `devx service react restart`
-1.  Restart web: `devx service web restart`
-1.  HMR + file watching works!
-
-### Remove the link
-
-1.  In `patreon_react_features` execute `rm app/libs/niondev`
-1.  Restart react: `devx service react restart`
-1.  Restart web: `devx service web restart`
-1.  That's it!
-
 ## Read More 📚
 
 -   [Declarations](docs/declarations.md)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ export default function configureStore() {
 
 [Read more about configuring nion in the docs.](docs/configuration.md)
 
+## Developing in PRF
+
+1.  Make sure `nion` is a sibling to `patreon_react_features` in a `devx` synced folder
+1.  In `patreon_react_features` execute `npm run link:nion`
+1.  In `nion` execute `npm run build`
+1.  Restart react: `devx service react restart`
+1.  Restart web: `devx service web restart`
+1.  HMR + file watching works!
+
+### Remove the link
+
+1.  In `patreon_react_features` execute `rm app/libs/niondev`
+1.  Restart react: `devx service react restart`
+1.  Restart web: `devx service web restart`
+1.  That's it!
+
 ## Read More 📚
 
 -   [Declarations](docs/declarations.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.0.6",
+    "version": "3.0.7",
     "license": "MIT",
     "browser": "es/index.js",
     "main": "lib/index.js",

--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -5,7 +5,7 @@ import union from 'lodash/union'
 import ApiManager from '../api'
 
 import * as actionTypes from './types'
-import apiActions from './index'
+import apiActions, { getObjectFromResponseText } from './index'
 
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
@@ -183,7 +183,68 @@ describe('nion: actions', () => {
             })
         })
     })
+
+    describe('getObjectFromResponseText', () => {
+
+        it('return valid object for non-empty json text', async () => {
+            const text = '{ "noam":"chomsky", "manufacturing":"consent"}'
+            const expected = {
+                noam: "chomsky",
+                manufacturing: "consent",
+            }
+
+            const result = getObjectFromResponseText({text})
+
+            expect(result).toEqual(expected)
+        })
+
+        it('return empty object for null text', async () => {
+            const text = null
+            const expected = {}
+
+            const result = getObjectFromResponseText({text})
+
+            expect(result).toEqual(expected)
+        })
+
+        it('return empty object for undefined text', async () => {
+            const text = undefined
+            const expected = {}
+
+            const result = getObjectFromResponseText({text})
+
+            expect(result).toEqual(expected)
+        })
+
+        it('return empty object for empty text', async () => {
+            const text = ''
+            const expected = {}
+
+            const result = getObjectFromResponseText({text})
+
+            expect(result).toEqual(expected)
+        })
+
+        it('return empty object for html text', async () => {
+            const text = '<html>noam-chomsky</html>'
+            const expected = {}
+
+            const result = getObjectFromResponseText({text})
+
+            expect(result).toEqual(expected)
+        })
+
+        it('return empty object for regular text', async () => {
+            const text = 'manufacturing consent'
+            const expected = {}
+
+            const result = getObjectFromResponseText({text})
+
+            expect(result).toEqual(expected)
+        })
+    })
 })
+
 
 function assertEqualAction(expected, observed) {
     expect(expected.type).toEqual(observed.type)

--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -5,7 +5,7 @@ import union from 'lodash/union'
 import ApiManager from '../api'
 
 import * as actionTypes from './types'
-import apiActions, { getObjectFromResponseText } from './index'
+import apiActions, { getDataFromResponseText } from './index'
 
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
@@ -184,7 +184,7 @@ describe('nion: actions', () => {
         })
     })
 
-    describe('getObjectFromResponseText', () => {
+    describe('getDataFromResponseText', () => {
 
         it('return valid object for non-empty json text', async () => {
             const text = '{ "noam":"chomsky", "manufacturing":"consent"}'
@@ -193,7 +193,7 @@ describe('nion: actions', () => {
                 manufacturing: "consent",
             }
 
-            const result = getObjectFromResponseText({text})
+            const result = getDataFromResponseText({text})
 
             expect(result).toEqual(expected)
         })
@@ -202,7 +202,7 @@ describe('nion: actions', () => {
             const text = null
             const expected = {}
 
-            const result = getObjectFromResponseText({text})
+            const result = getDataFromResponseText({text})
 
             expect(result).toEqual(expected)
         })
@@ -211,7 +211,7 @@ describe('nion: actions', () => {
             const text = undefined
             const expected = {}
 
-            const result = getObjectFromResponseText({text})
+            const result = getDataFromResponseText({text})
 
             expect(result).toEqual(expected)
         })
@@ -220,7 +220,7 @@ describe('nion: actions', () => {
             const text = ''
             const expected = {}
 
-            const result = getObjectFromResponseText({text})
+            const result = getDataFromResponseText({text})
 
             expect(result).toEqual(expected)
         })
@@ -229,7 +229,7 @@ describe('nion: actions', () => {
             const text = '<html>noam-chomsky</html>'
             const expected = {}
 
-            const result = getObjectFromResponseText({text})
+            const result = getDataFromResponseText({text})
 
             expect(result).toEqual(expected)
         })
@@ -238,7 +238,7 @@ describe('nion: actions', () => {
             const text = 'manufacturing consent'
             const expected = {}
 
-            const result = getObjectFromResponseText({text})
+            const result = getDataFromResponseText({text})
 
             expect(result).toEqual(expected)
         })

--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -185,15 +185,14 @@ describe('nion: actions', () => {
     })
 
     describe('getDataFromResponseText', () => {
-
         it('return valid object for non-empty json text', async () => {
             const text = '{ "noam":"chomsky", "manufacturing":"consent"}'
             const expected = {
-                noam: "chomsky",
-                manufacturing: "consent",
+                noam: 'chomsky',
+                manufacturing: 'consent',
             }
 
-            const result = getDataFromResponseText({text})
+            const result = getDataFromResponseText({ text })
 
             expect(result).toEqual(expected)
         })
@@ -202,7 +201,7 @@ describe('nion: actions', () => {
             const text = null
             const expected = {}
 
-            const result = getDataFromResponseText({text})
+            const result = getDataFromResponseText({ text })
 
             expect(result).toEqual(expected)
         })
@@ -211,7 +210,7 @@ describe('nion: actions', () => {
             const text = undefined
             const expected = {}
 
-            const result = getDataFromResponseText({text})
+            const result = getDataFromResponseText({ text })
 
             expect(result).toEqual(expected)
         })
@@ -220,7 +219,7 @@ describe('nion: actions', () => {
             const text = ''
             const expected = {}
 
-            const result = getDataFromResponseText({text})
+            const result = getDataFromResponseText({ text })
 
             expect(result).toEqual(expected)
         })
@@ -229,7 +228,7 @@ describe('nion: actions', () => {
             const text = '<html>noam-chomsky</html>'
             const expected = {}
 
-            const result = getDataFromResponseText({text})
+            const result = getDataFromResponseText({ text })
 
             expect(result).toEqual(expected)
         })
@@ -238,13 +237,12 @@ describe('nion: actions', () => {
             const text = 'manufacturing consent'
             const expected = {}
 
-            const result = getDataFromResponseText({text})
+            const result = getDataFromResponseText({ text })
 
             expect(result).toEqual(expected)
         })
     })
 })
-
 
 function assertEqualAction(expected, observed) {
     expect(expected.type).toEqual(observed.type)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -69,14 +69,19 @@ const apiAction = (method, dataKey, options) => _dispatch => {
 
             // Handle the case that calling response.json() on null responses throws a syntax error
             const text = await response.text()
-            const json = text ? JSON.parse(text) : {}
+            // const text = null
+            const objectFromJson = getObjectFromResponseText({ text })
+            // const objectFromJson = text ? JSON.parse(text) : {}
+            // const objectFromJson = JSON.parse(text)
+            console.log('[eb] test nion dev 722')
 
             // Handle any request errors since fetch doesn't throw
             if (!response.ok) {
+                console.log('[eb] response not ok')
                 const { status, statusText } = response
                 throw new ErrorClass(status, statusText, {
                     ...response,
-                    ...json,
+                    ...objectFromJson,
                 })
             }
 
@@ -90,7 +95,7 @@ const apiAction = (method, dataKey, options) => _dispatch => {
                 },
                 payload: {
                     requestType: apiType,
-                    responseData: parse(json),
+                    responseData: parse(objectFromJson),
                 },
             })
 
@@ -120,6 +125,19 @@ const apiAction = (method, dataKey, options) => _dispatch => {
 
 const getAction = (dataKey, options) => {
     return apiAction('GET', dataKey, options)
+}
+
+export const getObjectFromResponseText = ({ text }) => {
+    // get object from response text json string. return {} if text is falsey or is not valid json string format.
+    const defaultObject = {}
+    try {
+        return text ? JSON.parse(text) : defaultObject
+    } catch (error) {
+        if (error instanceof TypeError || error instanceof SyntaxError) {
+            return defaultObject
+        }
+        throw error
+    }
 }
 
 const postAction = (dataKey, options) => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -10,6 +10,19 @@ import {
 import { selectData } from '../selectors'
 import Lifecycle from '../lifecycle'
 
+export const getDataFromResponseText = ({ text }) => {
+    // get data object from response text json string. return {} if text is falsey or is not valid json string format.
+    const defaultObject = {}
+    try {
+        return text ? JSON.parse(text) : defaultObject
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            return defaultObject
+        }
+        throw error
+    }
+}
+
 const apiAction = (method, dataKey, options) => _dispatch => {
     const { body, declaration = {}, endpoint } = options
 
@@ -120,19 +133,6 @@ const apiAction = (method, dataKey, options) => _dispatch => {
 
 const getAction = (dataKey, options) => {
     return apiAction('GET', dataKey, options)
-}
-
-export const getDataFromResponseText = ({ text }) => {
-    // get data object from response text json string. return {} if text is falsey or is not valid json string format.
-    const defaultObject = {}
-    try {
-        return text ? JSON.parse(text) : defaultObject
-    } catch (error) {
-        if (error instanceof SyntaxError) {
-            return defaultObject
-        }
-        throw error
-    }
 }
 
 const postAction = (dataKey, options) => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -69,19 +69,14 @@ const apiAction = (method, dataKey, options) => _dispatch => {
 
             // Handle the case that calling response.json() on null responses throws a syntax error
             const text = await response.text()
-            // const text = null
-            const objectFromJson = getObjectFromResponseText({ text })
-            // const objectFromJson = text ? JSON.parse(text) : {}
-            // const objectFromJson = JSON.parse(text)
-            console.log('[eb] test nion dev 722')
+            const data = getDataFromResponseText({ text })
 
             // Handle any request errors since fetch doesn't throw
             if (!response.ok) {
-                console.log('[eb] response not ok')
                 const { status, statusText } = response
                 throw new ErrorClass(status, statusText, {
                     ...response,
-                    ...objectFromJson,
+                    ...data,
                 })
             }
 
@@ -95,7 +90,7 @@ const apiAction = (method, dataKey, options) => _dispatch => {
                 },
                 payload: {
                     requestType: apiType,
-                    responseData: parse(objectFromJson),
+                    responseData: parse(data),
                 },
             })
 
@@ -127,8 +122,8 @@ const getAction = (dataKey, options) => {
     return apiAction('GET', dataKey, options)
 }
 
-export const getObjectFromResponseText = ({ text }) => {
-    // get object from response text json string. return {} if text is falsey or is not valid json string format.
+export const getDataFromResponseText = ({ text }) => {
+    // get data object from response text json string. return {} if text is falsey or is not valid json string format.
     const defaultObject = {}
     try {
         return text ? JSON.parse(text) : defaultObject

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -128,7 +128,7 @@ export const getDataFromResponseText = ({ text }) => {
     try {
         return text ? JSON.parse(text) : defaultObject
     } catch (error) {
-        if (error instanceof TypeError || error instanceof SyntaxError) {
+        if (error instanceof SyntaxError) {
             return defaultObject
         }
         throw error

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -14,8 +14,10 @@ export const getDataFromResponseText = ({ text }) => {
     // get data object from response text json string. return {} if text is falsey or is not valid json string format.
     const defaultObject = {}
     try {
+        // if text is null/empty/falsey, return default empty object
         return text ? JSON.parse(text) : defaultObject
     } catch (error) {
+        // if text is invalid json syntax, return default empty object, and let nion log error from api response instead
         if (error instanceof SyntaxError) {
             return defaultObject
         }


### PR DESCRIPTION
we get lots of json related syntax errors, such as:
```
SyntaxError
JSON.parse: unexpected character at line 1 column 1 of the JSON data
```

however these json syntax errors are often concealing the real underlying error, which is that the api response is returning something unexpected, other than valid json, like an html page.

this solution will handle invalid json better so that instead of erroring out on parse, we set a default empty data object and then either continue with empty data or log a more appropriate error message.