### PR TITLE
PX-2461 Resume running integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
         ],
         "testMatch": [
             "**/src/**/__tests__/**/*.[jt]s?(x)",
-            "**/src/**/?(*.)+(spec|test).[jt]s?(x)"
+            "**/src/**/?(*.)+(spec|test).[jt]s?(x)",
+            "**/test/**/?(*.)+(spec|test).[jt]s?(x)"
         ],
         "transform": {
             "\\.js$": "babel-jest"

--- a/test/hooks-integration.test.js
+++ b/test/hooks-integration.test.js
@@ -45,6 +45,17 @@ const baseUrl = 'http://api.test.com'
 const buildUrl = path =>
     path.startsWith('/') ? baseUrl + path : baseUrl + '/' + path
 
+const getNionProps = NionComponent => {
+    let returned
+
+    act(() => {
+        NionComponent.update()
+        returned = NionComponent.find('div').prop('returned')
+    })
+
+    return returned
+}
+
 describe('nion hooks: integration tests', () => {
     afterEach(() => {
         nock.cleanAll()
@@ -60,16 +71,14 @@ describe('nion hooks: integration tests', () => {
                 return <div returned={returned} />
             }
 
-            const Wrapper = mount(Wrap(Container))
-            const Wrapped = Wrapper.find('div')
+            let Wrapper
 
-            const returned = Wrapped.prop('returned')
-
-            expect(returned).toBeDefined()
-            expect(returned[0]).toBeDefined()
+            act(() => {
+                Wrapper = mount(Wrap(Container))
+            })
 
             // Test the expected nion dataProp API interface
-            const [test, actions, request] = returned
+            const [test, actions, request] = getNionProps(Wrapper)
 
             // Actions
             expect(actions.get).toBeDefined()
@@ -110,16 +119,13 @@ describe('nion hooks: integration tests', () => {
                 return <div returned={returned} />
             }
 
-            const Wrapper = mount(Wrap(Container))
+            let Wrapper
 
-            const getProp = () => {
-                act(() => {
-                    Wrapper.update()
-                })
-                return Wrapper.find('div').prop('returned')
-            }
+            act(() => {
+                Wrapper = mount(Wrap(Container))
+            })
 
-            let [test, actions, request] = getProp()
+            let [test, actions, request] = getNionProps(Wrapper)
 
             let waitingFor
 
@@ -127,13 +133,12 @@ describe('nion hooks: integration tests', () => {
                 waitingFor = actions.get()
             })
 
-            await P.delay(0) // wait for useEffect to go
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
         })
@@ -163,16 +168,15 @@ describe('nion hooks: integration tests', () => {
                 return <div returned={returned} />
             }
 
-            const Wrapper = mount(Wrap(Container))
+            let Wrapper
 
-            const getProp = () =>
-                Wrapper.update()
-                    .find('div')
-                    .prop('returned')
+            act(() => {
+                Wrapper = mount(Wrap(Container))
+            })
 
             await P.delay(15) // Wait 15ms for the request reducer to update
 
-            const [test, _, request] = getProp()
+            const [test, _, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
         })
@@ -210,32 +214,37 @@ describe('nion hooks: integration tests', () => {
                 return <div returned={returned} />
             }
 
-            const Wrapper = mount(Wrap(Container))
+            let Wrapper
 
-            const getProp = () =>
-                Wrapper.update()
-                    .find('div')
-                    .prop('returned')
+            act(() => {
+                Wrapper = mount(Wrap(Container))
+            })
 
-            let [test, actions, request] = getProp()
-            let waitingFor = actions.get()
-            ;[test, actions, request] = getProp()
+            let [test, actions, request] = getNionProps(Wrapper)
+            let waitingFor
+
+            act(() => {
+                waitingFor = actions.get()
+            })
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
 
             // Patch request
-            waitingFor = actions.patch()
-            ;[test, actions, request] = getProp()
+            act(() => {
+                waitingFor = actions.patch()
+            })
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(newName)
         })
@@ -266,28 +275,34 @@ describe('nion hooks: integration tests', () => {
                 return <div returned={returned} />
             }
 
-            const Wrapper = mount(Wrap(Container))
+            let Wrapper
 
-            const getProp = () =>
-                Wrapper.update()
-                    .find('div')
-                    .prop('returned')
+            act(() => {
+                Wrapper = mount(Wrap(Container))
+            })
 
-            let [test, actions, request] = getProp()
-            let waitingFor = actions.get()
+            let [test, actions, request] = getNionProps(Wrapper)
+            let waitingFor
 
-            ;[test, actions, request] = getProp()
+            act(() => {
+                waitingFor = actions.get()
+            })
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
 
             // Delete request
-            await actions.delete()
-            ;[test, actions, request] = getProp()
+            act(() => {
+                waitingFor = actions.delete()
+            })
+
+            await waitingFor
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('success')
 
             expect(!!test).toEqual(false)
@@ -307,20 +322,23 @@ describe('nion hooks: integration tests', () => {
                 return <div returned={returned} />
             }
 
-            const Wrapper = mount(Wrap(Container))
+            let Wrapper
 
-            const getProp = () =>
-                Wrapper.update()
-                    .find('div')
-                    .prop('returned')
+            act(() => {
+                Wrapper = mount(Wrap(Container))
+            })
 
-            let [_test, actions, request] = getProp()
-            let waitingFor = actions.get()
+            let [_test, actions, request] = getNionProps(Wrapper)
+            let waitingFor
+
+            act(() => {
+                waitingFor = actions.get()
+            })
 
             await waitingFor.catch(err => {
                 expect(err).toBeInstanceOf(Error)
             })
-            ;[_test, actions, request] = getProp()
+            ;[_test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('error')
             expect(request.isError).toEqual(true)
             expect(request.isLoading).toEqual(false)
@@ -348,26 +366,29 @@ describe('nion hooks: integration tests', () => {
                 return <div returned={returned} />
             }
 
-            const Wrapper = mount(Wrap(Container))
+            let Wrapper
 
-            const getProp = () =>
-                Wrapper.update()
-                    .find('div')
-                    .prop('returned')
+            act(() => {
+                Wrapper = mount(Wrap(Container))
+            })
 
-            let [test, actions, request] = getProp()
-            let waitingFor = actions.get()
-            ;[test, actions, request] = getProp()
+            let [test, actions, request] = getNionProps(Wrapper)
+            let waitingFor
+
+            act(() => {
+                waitingFor = actions.get()
+            })
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
 
             // Optimistic Update
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             act(() => {
                 actions.updateEntity(
                     {
@@ -379,7 +400,7 @@ describe('nion hooks: integration tests', () => {
                     },
                 )
             })
-            ;[test, actions, request] = getProp()
+            ;[test, actions, request] = getNionProps(Wrapper)
             expect(test.name).toEqual(newName)
         })
 
@@ -425,23 +446,15 @@ describe('nion hooks: integration tests', () => {
                 return test ? <ChildContainer inputData={test} /> : <span />
             }
 
-            const Wrapper = mount(Wrap(Container))
-            await P.delay(50)
-
-            // // Child component
-            const ChildWrapped = Wrapper.update().find('div')
-
-            const getProp = () => ChildWrapped.prop('returned')
-
-            await P.delay(20)
+            let Wrapper
 
             act(() => {
-                Wrapper.update()
+                Wrapper = mount(Wrap(Container))
             })
 
-            await P.delay(1)
+            await P.delay(15)
 
-            let child = getProp()
+            let child = getNionProps(Wrapper)
 
             expect(exists(child[0])).toEqual(true)
         })
@@ -450,6 +463,7 @@ describe('nion hooks: integration tests', () => {
 
 describe('hooks re-render performance', () => {
     let numRenders
+
     beforeEach(() => {
         numRenders = 0
     })
@@ -466,17 +480,20 @@ describe('hooks re-render performance', () => {
             })
 
             numRenders++
+
             return <div returned={returned} />
         }
-        let wrapped
+
+        let Wrapper
+
         act(() => {
-            wrapped = mount(Wrap(Container))
+            Wrapper = mount(Wrap(Container))
         })
 
         // 1 for change to state and 1 for the initial render
         expect(numRenders).toBe(2)
 
-        const [data1, actions] = wrapped.find('div').prop('returned')
+        const [data1, actions] = getNionProps(Wrapper)
 
         const endpoint = buildUrl('/test')
         nock(endpoint)
@@ -496,7 +513,8 @@ describe('hooks re-render performance', () => {
             a = actions.get()
         })
 
-        const [data2, actions2] = wrapped.find('div').prop('returned')
+        // TODO: Using `getNionProps(Wrapper)` fails `action` equality tests (calls `Wrapper.update()`)
+        const [data2, actions2] = Wrapper.find('div').prop('returned')
 
         expect(data2).toBe(data1)
         expect(actions).toBe(actions2)
@@ -504,11 +522,11 @@ describe('hooks re-render performance', () => {
         expect(numRenders).toBe(3)
 
         await a
-        await P.delay(1)
+        await P.delay(15)
 
         expect(numRenders).toBe(4)
 
-        const [, actions3] = wrapped.find('div').prop('returned')
+        const [, actions3] = Wrapper.find('div').prop('returned')
 
         expect(actions3).toBe(actions2)
     })

--- a/test/hooks-integration.test.js
+++ b/test/hooks-integration.test.js
@@ -276,7 +276,6 @@ describe('nion hooks: integration tests', () => {
             let [test, actions, request] = getProp()
             let waitingFor = actions.get()
 
-            await P.delay(0)
             ;[test, actions, request] = getProp()
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
@@ -300,7 +299,6 @@ describe('nion hooks: integration tests', () => {
             const endpoint = buildUrl(pathname)
             nock(endpoint)
                 .get('')
-                .delay(2000)
                 .query(true)
                 .reply(404)
 
@@ -454,6 +452,10 @@ describe('hooks re-render performance', () => {
     let numRenders
     beforeEach(() => {
         numRenders = 0
+    })
+
+    afterEach(() => {
+        nock.cleanAll()
     })
 
     it('should only render once per action with minimal config', async () => {

--- a/test/hooks-integration.test.js
+++ b/test/hooks-integration.test.js
@@ -462,11 +462,9 @@ describe('hooks re-render performance', () => {
                 dataKey: 'test',
                 endpoint: buildUrl('/test'),
             })
-            return React.useMemo(() => {
-                numRenders += 1
-                return <div returned={returned} />
-                // eslint-disable-next-line react-hooks/exhaustive-deps
-            }, returned)
+
+            numRenders++
+            return <div returned={returned} />
         }
         let wrapped
         act(() => {
@@ -474,7 +472,7 @@ describe('hooks re-render performance', () => {
         })
 
         // 1 for change to state and 1 for the initial render
-        expect(numRenders).toBe(1)
+        expect(numRenders).toBe(2)
 
         const [data1, actions] = wrapped.find('div').prop('returned')
 
@@ -501,12 +499,12 @@ describe('hooks re-render performance', () => {
         expect(data2).toBe(data1)
         expect(actions).toBe(actions2)
 
-        expect(numRenders).toBe(2)
+        expect(numRenders).toBe(3)
 
         await a
         await P.delay(1)
 
-        expect(numRenders).toBe(3)
+        expect(numRenders).toBe(4)
 
         const [, actions3] = wrapped.find('div').prop('returned')
 

--- a/test/hooks-integration.test.js
+++ b/test/hooks-integration.test.js
@@ -45,6 +45,27 @@ const baseUrl = 'http://api.test.com'
 const buildUrl = path =>
     path.startsWith('/') ? baseUrl + path : baseUrl + '/' + path
 
+const createTestNionComponent = onRender => {
+    function Container() {
+        const returned = useNion({
+            dataKey: 'test',
+            endpoint: buildUrl('/test'),
+        })
+
+        if (typeof onRender === 'function') onRender()
+
+        return <div returned={returned} />
+    }
+
+    let Wrapped
+
+    act(() => {
+        Wrapped = mount(Wrap(Container))
+    })
+
+    return Wrapped
+}
+
 const getNionProps = NionComponent => {
     let returned
 
@@ -63,22 +84,10 @@ describe('nion hooks: integration tests', () => {
 
     describe('nion decorator', () => {
         it('injects props into the component', async () => {
-            function Container() {
-                const returned = useNion({
-                    dataKey: 'test',
-                    endpoint: buildUrl('/test'),
-                })
-                return <div returned={returned} />
-            }
-
-            let Wrapper
-
-            act(() => {
-                Wrapper = mount(Wrap(Container))
-            })
+            const c = createTestNionComponent()
 
             // Test the expected nion dataProp API interface
-            const [test, actions, request] = getNionProps(Wrapper)
+            const [test, actions, request] = getNionProps(c)
 
             // Actions
             expect(actions.get).toBeDefined()
@@ -114,31 +123,21 @@ describe('nion hooks: integration tests', () => {
                     },
                 })
 
-            function Container() {
-                const returned = useNion({ dataKey: 'test', endpoint })
-                return <div returned={returned} />
-            }
+            const c = createTestNionComponent()
 
-            let Wrapper
-
-            act(() => {
-                Wrapper = mount(Wrap(Container))
-            })
-
-            let [test, actions, request] = getNionProps(Wrapper)
+            let [test, actions, request] = getNionProps(c)
 
             let waitingFor
 
             act(() => {
                 waitingFor = actions.get()
             })
-
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
         })
@@ -209,29 +208,20 @@ describe('nion hooks: integration tests', () => {
                     },
                 })
 
-            function Container() {
-                const returned = useNion({ dataKey: 'test', endpoint })
-                return <div returned={returned} />
-            }
+            const c = createTestNionComponent()
 
-            let Wrapper
-
-            act(() => {
-                Wrapper = mount(Wrap(Container))
-            })
-
-            let [test, actions, request] = getNionProps(Wrapper)
+            let [test, actions, request] = getNionProps(c)
             let waitingFor
 
             act(() => {
                 waitingFor = actions.get()
             })
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
 
@@ -239,12 +229,12 @@ describe('nion hooks: integration tests', () => {
             act(() => {
                 waitingFor = actions.patch()
             })
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(newName)
         })
@@ -270,29 +260,20 @@ describe('nion hooks: integration tests', () => {
                 .query(true)
                 .reply(204)
 
-            function Container() {
-                const returned = useNion({ dataKey: 'test', endpoint })
-                return <div returned={returned} />
-            }
+            const c = createTestNionComponent()
 
-            let Wrapper
-
-            act(() => {
-                Wrapper = mount(Wrap(Container))
-            })
-
-            let [test, actions, request] = getNionProps(Wrapper)
+            let [test, actions, request] = getNionProps(c)
             let waitingFor
 
             act(() => {
                 waitingFor = actions.get()
             })
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
 
@@ -302,7 +283,7 @@ describe('nion hooks: integration tests', () => {
             })
 
             await waitingFor
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('success')
 
             expect(!!test).toEqual(false)
@@ -317,18 +298,9 @@ describe('nion hooks: integration tests', () => {
                 .query(true)
                 .reply(404)
 
-            function Container() {
-                const returned = useNion({ dataKey: 'test', endpoint })
-                return <div returned={returned} />
-            }
+            const c = createTestNionComponent()
 
-            let Wrapper
-
-            act(() => {
-                Wrapper = mount(Wrap(Container))
-            })
-
-            let [_test, actions, request] = getNionProps(Wrapper)
+            let [_test, actions, request] = getNionProps(c)
             let waitingFor
 
             act(() => {
@@ -338,7 +310,7 @@ describe('nion hooks: integration tests', () => {
             await waitingFor.catch(err => {
                 expect(err).toBeInstanceOf(Error)
             })
-            ;[_test, actions, request] = getNionProps(Wrapper)
+            ;[_test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('error')
             expect(request.isError).toEqual(true)
             expect(request.isLoading).toEqual(false)
@@ -361,34 +333,25 @@ describe('nion hooks: integration tests', () => {
                     },
                 })
 
-            function Container() {
-                const returned = useNion({ dataKey: 'test', endpoint })
-                return <div returned={returned} />
-            }
+            const c = createTestNionComponent()
 
-            let Wrapper
-
-            act(() => {
-                Wrapper = mount(Wrap(Container))
-            })
-
-            let [test, actions, request] = getNionProps(Wrapper)
+            let [test, actions, request] = getNionProps(c)
             let waitingFor
 
             act(() => {
                 waitingFor = actions.get()
             })
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('pending')
             expect(request.isLoading).toEqual(true)
 
             await waitingFor
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(request.status).toEqual('success')
             expect(test.name).toEqual(name)
 
             // Optimistic Update
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             act(() => {
                 actions.updateEntity(
                     {
@@ -400,7 +363,7 @@ describe('nion hooks: integration tests', () => {
                     },
                 )
             })
-            ;[test, actions, request] = getNionProps(Wrapper)
+            ;[test, actions, request] = getNionProps(c)
             expect(test.name).toEqual(newName)
         })
 
@@ -446,17 +409,23 @@ describe('nion hooks: integration tests', () => {
                 return test ? <ChildContainer inputData={test} /> : <span />
             }
 
-            let Wrapper
+            let ParentComponent
 
             act(() => {
-                Wrapper = mount(Wrap(Container))
+                ParentComponent = mount(Wrap(Container))
             })
 
             await P.delay(15)
 
-            let child = getNionProps(Wrapper)
+            let ChildComponent
 
-            expect(exists(child[0])).toEqual(true)
+            act(() => {
+                ChildComponent = ParentComponent.update().find('div')
+            })
+
+            const childNionProps = ChildComponent.prop('returned')
+
+            expect(childNionProps.length).toEqual(4)
         })
     })
 })
@@ -473,27 +442,12 @@ describe('hooks re-render performance', () => {
     })
 
     it('should only render once per action with minimal config', async () => {
-        function Container() {
-            const returned = useNion({
-                dataKey: 'test',
-                endpoint: buildUrl('/test'),
-            })
-
-            numRenders++
-
-            return <div returned={returned} />
-        }
-
-        let Wrapper
-
-        act(() => {
-            Wrapper = mount(Wrap(Container))
-        })
+        const c = createTestNionComponent(() => numRenders++)
 
         // 1 for change to state and 1 for the initial render
         expect(numRenders).toBe(2)
 
-        const [data1, actions] = getNionProps(Wrapper)
+        const [data1, actions] = getNionProps(c)
 
         const endpoint = buildUrl('/test')
         nock(endpoint)
@@ -514,7 +468,7 @@ describe('hooks re-render performance', () => {
         })
 
         // TODO: Using `getNionProps(Wrapper)` fails `action` equality tests (calls `Wrapper.update()`)
-        const [data2, actions2] = Wrapper.find('div').prop('returned')
+        const [data2, actions2] = c.find('div').prop('returned')
 
         expect(data2).toBe(data1)
         expect(actions).toBe(actions2)
@@ -526,7 +480,7 @@ describe('hooks re-render performance', () => {
 
         expect(numRenders).toBe(4)
 
-        const [, actions3] = Wrapper.find('div').prop('returned')
+        const [, actions3] = c.find('div').prop('returned')
 
         expect(actions3).toBe(actions2)
     })


### PR DESCRIPTION
I will be doing more work in service of ["PX-2461 useNion hook updates too often on cold page load"](https://patreon.atlassian.net/browse/PX-2461) but wanted to open a baseline PR to correct some upfront issues (and improve readability of any future PRs):

1. Integration tests under **/test** not being run at all
1. Failing `re-render performance` test in **hooks-integration.test.js**

While I was in **hooks-integration.test.js**, I also performed some cleanup:

1. DRY up a bunch of repeated test setup
1. Wrapped more component ops in `act()` (some console warnings remain)
1. Removed unnecessary 2 second delay in one of the tests