### PR TITLE
Use isomorphic-fetch ^2.2.1 & reduce package size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 # built files
 lib
 es
+*.tgz
 
 # coverage output from jest
 coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -4574,7 +4574,6 @@
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-            "dev": true,
             "requires": {
                 "iconv-lite": "~0.4.13"
             }
@@ -6508,8 +6507,7 @@
         "iconv-lite": {
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-            "dev": true
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
         "ignore": {
             "version": "4.0.6",
@@ -6858,8 +6856,7 @@
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-string": {
             "version": "1.0.4",
@@ -6916,24 +6913,12 @@
             "dev": true
         },
         "isomorphic-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
             "requires": {
-                "node-fetch": "^2.6.1",
-                "whatwg-fetch": "^3.4.1"
-            },
-            "dependencies": {
-                "node-fetch": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-                },
-                "whatwg-fetch": {
-                    "version": "3.6.2",
-                    "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-                    "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-                }
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
             }
         },
         "isstream": {
@@ -8656,7 +8641,6 @@
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
             "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-            "dev": true,
             "requires": {
                 "encoding": "^0.1.11",
                 "is-stream": "^1.0.1"
@@ -11309,8 +11293,7 @@
         "whatwg-fetch": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-            "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
-            "dev": true
+            "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
         },
         "whatwg-mimetype": {
             "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,17 @@
     "name": "@nion/nion",
     "version": "3.1.0",
     "license": "MIT",
-    "browser": "es/index.js",
-    "main": "lib/index.js",
+    "browser": "./es/index.js",
+    "main": "./lib/index.js",
     "types": "./types/index.d.ts",
     "sideEffects": false,
+    "files": [
+        "/es",
+        "!/es/**/*.test.js",
+        "/lib",
+        "!/lib/**/*.test.js",
+        "types/index.d.ts"
+    ],
     "eslintConfig": {
         "globals": {
             "window": true,
@@ -18,7 +25,7 @@
         "deep-equal": "^1.0.1",
         "humps": "^2.0.1",
         "is-equal-shallow": "^0.1.3",
-        "isomorphic-fetch": "^3.0.0",
+        "isomorphic-fetch": "^2.2.1",
         "lodash": "^4.17.20",
         "reselect": "^3.0.1",
         "seamless-immutable": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "license": "MIT",
     "browser": "./es/index.js",
     "main": "./lib/index.js",


### PR DESCRIPTION
# Update isomorphic-fetch package version

Not looking to rock boat, should have stuck with `isomorphic-fetch: ^2.2.1` when switching off forked version earlier

# Reduced NPM package size
## Before
```
package size: 224.1 kB
unpacked size: 582.2 kB
total files: 137    
```
## After
```
package size: 50.9 kB
unpacked size: 255.4 kB
total files: 77
```