### PR TITLE
Reintroduce `deps` array for useNion hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "license": "MIT",
     "browser": "./es/index.js",
     "main": "./lib/index.js",

--- a/src/hook/useNion.js
+++ b/src/hook/useNion.js
@@ -15,6 +15,8 @@ import { prepareStackTrace, withStats } from '../devtool/hooks'
 
 export const ERROR_INVALID_NION_ACTION = 'Invalid Nion action'
 
+const EMPTY_DEPS = []
+
 function coerceDeclaration(declaration) {
     return typeof declaration === 'string'
         ? { dataKey: declaration }
@@ -61,7 +63,7 @@ function makeResCallback(method, decl, dispatch) {
     }
 }
 
-function useNion(declaration) {
+function useNion(declaration, deps = EMPTY_DEPS) {
     const dispatch = useDispatch()
 
     const [decl, dataKey, fetchOnMount, initialRef] = useMemo(() => {
@@ -73,7 +75,7 @@ function useNion(declaration) {
             coerced?.fetchOnMount,
             coerced?.initialRef,
         ]
-    }, [declaration])
+    }, deps) // eslint-disable-line react-hooks/exhaustive-deps
 
     const mapStateToProps = useCallback(
         state => ({


### PR DESCRIPTION
If we want recent changes to be truly backwards compatible, we can't remove `deps` behavior & rely on `declaration` alone