### PR TITLE
Fix denormalize entity ref access broken by 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nion/nion",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "license": "MIT",
     "browser": "./es/index.js",
     "main": "./lib/index.js",

--- a/src/denormalize/cache.js
+++ b/src/denormalize/cache.js
@@ -24,14 +24,14 @@ class DenormalizationCache {
         this.denorm[type][id] = data
     }
 
-    getDenormalized = (type, id) => this.denorm[type] && this.denorm[type][id]
+    getDenormalized = (type, id) => this.denorm[type]?.[id]
 
     addEntity = entity => {
         this.entities[entity.type] = this.entities[entity.type] || {}
         this.entities[entity.type][entity.id] = entity
     }
 
-    getEntity = (type, id) => this.entities[type] && this.entities[type][id]
+    getEntity = (type, id) => this.entities[type]?.[id]
 
     addManifest = (entity, manifest) => {
         const { type, id } = entity
@@ -42,14 +42,13 @@ class DenormalizationCache {
         mergeManifests(this.manifests[type][id], manifest)
     }
 
-    getManifest = (type, id) => this.manifests[type] && this.manifests[type][id]
+    getManifest = (type, id) => this.manifests[type]?.[id]
 
     hasDataChanged = (ref, entityStore) => {
         if (!entityStore) return true
 
         if (
-            this.getEntity(ref.type, ref.id) !==
-            (entityStore[ref.type] && entityStore[ref.type][ref.id])
+            this.getEntity(ref.type, ref.id) !== entityStore[ref.type]?.[ref.id]
         ) {
             return true
         }
@@ -63,8 +62,7 @@ class DenormalizationCache {
                         const { type, id } = manifest[entityType][entityId]
 
                         if (
-                            this.getEntity(type, id) !==
-                            (entityStore[type] && entityStore[type][id])
+                            this.getEntity(type, id) !== entityStore[type]?.[id]
                         ) {
                             return true
                         }

--- a/src/denormalize/index.js
+++ b/src/denormalize/index.js
@@ -42,7 +42,7 @@ export function getGenericRefData(ref) {
 
 export const addEntityReference = (obj, value) => obj && obj.set('_ref', value)
 
-export const getEntityReference = obj => obj._ref
+export const getEntityReference = obj => obj?._ref
 
 export const hasEntityReference = obj => Boolean(getEntityReference(obj))
 
@@ -68,7 +68,7 @@ export const hasEntityReference = obj => Boolean(getEntityReference(obj))
 // in downstream selectors, redux connect functions, or componentShouldUpdate methods to optimize
 // re-render performance
 function denormalize(ref, entityStore, existingObjects = {}) {
-    if (!(ref && ref.type && ref.id)) {
+    if (!(ref?.type && ref?.id)) {
         return { denormalized: undefined }
     }
 
@@ -88,8 +88,7 @@ function denormalize(ref, entityStore, existingObjects = {}) {
 
     // Check the existing object to see if a reference to the denormalized object already exists,
     // if so, use the existing denormalized object
-    const existingObject =
-        existingObjects && existingObjects[type] && existingObjects[type][id]
+    const existingObject = existingObjects?.[type]?.[id]
 
     if (existingObject) {
         return {
@@ -99,7 +98,7 @@ function denormalize(ref, entityStore, existingObjects = {}) {
     }
 
     // Otherwise, fetch the entity from the entity store
-    const entity = entityStore && entityStore[type] && entityStore[type][id]
+    const entity = entityStore?.[type]?.[id]
 
     if (entity === undefined) {
         return { denormalized: undefined }


### PR DESCRIPTION
While we're at it, clean some lines up with optional chaining