### PR TITLE
Fix propTypes warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
         ],
         "testMatch": [
             "**/src/**/__tests__/**/*.[jt]s?(x)",
-            "**/src/**/?(*.)+(spec|test).[jt]s?(x)"
+            "**/src/**/?(*.)+(spec|test).[jt]s?(x)",
+            "**/test/**?(*.)+(spec|test).[jt]s?(x)"
         ],
         "transform": {
             "\\.js$": "babel-jest"

--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -457,6 +457,13 @@ const nion = (declarations = {}, ...rest) => WrappedComponent => {
     ).map(key => {
         connectedComponent[key] = WrappedComponent[key]
     })
+    // Remove nion from the propTypes of the connected component, if it exists,
+    // since it will be injected by withNion
+    if (connectedComponent.propTypes) {
+        const { nion: _, ...restProps } = connectedComponent.propTypes
+        connectedComponent.propTypes = restProps
+    }
+
     return connectedComponent
 }
 

--- a/src/decorator/test/index.test.js
+++ b/src/decorator/test/index.test.js
@@ -1,0 +1,49 @@
+import nion from '../'
+import React from 'react'
+import PropTypes from 'prop-types'
+import { mount } from 'enzyme'
+
+import { Provider } from 'react-redux'
+import configureTestStore from '../../../test/configure-test-store'
+
+describe('nion', () => {
+    describe('propTypes validation', () => {
+        let OuterComponent
+        let originalConsoleError
+        let store
+
+        beforeAll(() => {
+            originalConsoleError = global.console.error
+            // Treat all console.errors as test failures to catch failed propType validation
+            global.console.error = (...args) => {
+                throw new Error(args[0])
+            }
+        })
+
+        afterAll(() => {
+            global.console.error = originalConsoleError
+        })
+
+        beforeEach(() => {
+            class WrappedComponent extends React.Component {
+                static propTypes = {
+                    nion: PropTypes.object.isRequired,
+                }
+
+                render() {
+                    return null
+                }
+            }
+            OuterComponent = nion()(WrappedComponent)
+            store = configureTestStore()
+        })
+
+        it('has no propTypes errors', () => {
+            mount(
+                <Provider store={store}>
+                    <OuterComponent />
+                </Provider>,
+            )
+        })
+    })
+})

--- a/src/decorator/test/should-rerender.test.js
+++ b/src/decorator/test/should-rerender.test.js
@@ -6,7 +6,7 @@ import {
     extrasAreEqual,
     extensionsAreEqual,
     dataAreEqual,
-} from './should-rerender.js'
+} from '../should-rerender.js'
 
 const makeDataObject = (data = {}) => {
     return Immutable({ type: 'test', id: '123', ...data })


### PR DESCRIPTION
Currently, we copy all the properties of the wrapped component when wrapping it with nion, including propTypes. This causes situations where the wrapped component (correctly) declares that it requires the `nion` prop and this gets propagated to the connected component as well, which should *not* require the `nion` prop since it injects it to its child.

This PR fixes this issue by stripping the `nion` propType, if it exists, from the connected component.