### PR TITLE
added additional type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,7 @@ export interface NionRequest {
     isProcessing: boolean
     name?: string
     pending: boolean
-    status?: 'error' | 'pending' | 'success'
+    status?: 'not called' | 'error' | 'pending' | 'success'
     statusCode?: number
 }
 


### PR DESCRIPTION
The `status` key was missing thing `'not called'` option, which is a [totally valid](https://github.com/Patreon/nion/blob/master/src/selectors/index.js#L40-L46) and [well-tested](https://github.com/Patreon/nion/blob/master/test/hooks-integration.test.js#L82) option.

This PR will fix this issue: https://github.com/Patreon/nion/issues/136