### PR TITLE
adds type def to delete options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,9 +32,13 @@ export interface GetActionOptions {
     appendKey?: string
 }
 
+export interface DeleteActionOptions {
+    refToDelete?: NionRef
+}
+
 export interface Actions<T> {
     get(params?: any, actionOptions?: GetActionOptions): Promise<T>
-    delete(params?: any): Promise<T>
+    delete(params?: any, actionOptions?: DeleteActionOptions): Promise<T>
     put(params?: any): Promise<T>
     patch(body?: any, params?: any): Promise<T>
     post(body?: any, params?: any): Promise<T>


### PR DESCRIPTION
we are missing a type def for delete action options, adds `refToDelete` definition