### PR TITLE
Added response url to error class constructor

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -112,6 +112,9 @@ const apiAction = (method, dataKey, options) => _dispatch => {
             if (!response.ok) {
                 const { status, statusText } = response
                 throw new ErrorClass(status, statusText, {
+                    // The spread operator doesn't spread in built-in properties from Response objects, but we want
+                    // to be able to access the URL in the error class for logging purposes, so we pass it in explicitly
+                    url: response.url,
                     ...response,
                     ...data,
                 })


### PR DESCRIPTION
This is a follow up to an incident, where we're getting 503 `JsonApiError` instances in Cypress tests, but can't correlate them with the request that caused the error. To solve this, I'm going to print the pathname for the requested URL, but an issue with how the native `Response` object is defined in browsers means none of it's properties are spread in (prototypes aren't spread):

<img width="437" alt="Screenshot 2024-07-16 at 16 18 20" src="https://github.com/user-attachments/assets/1dab1147-460d-4688-a23b-dbf57093c250">


This PR explicitly adds the `url` property to the `ErrorClass`'s third argument so we can print this message in PRF.

For more information, see https://patreon.slack.com/archives/C07CJ8299K8/p1721165788053089