### PR TITLE
Move denormalization cache inside of store

### DIFF
--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -37,7 +37,7 @@ const getDefaultDeclarationOptions = () => ({
   requestParams: {},
 });
 
-const processDefaultOptions = declarations => {
+const processDefaultOptions = (declarations) => {
   // TODO (legacied no-unused-vars)
   // This failure is legacied in and should be updated. DO NOT COPY.
   // eslint-disable-next-line no-unused-vars
@@ -56,7 +56,7 @@ const processDeclarations = (inputDeclarations, ...rest) => {
   // params. We need to handle both the component-scoped key (the key of the object passed to
   // the decorator) as well as the dataKey that points to where the ref / request is stored on
   // the state tree
-  const mapDeclarations = fn =>
+  const mapDeclarations = (fn) =>
     map(declarations, (declaration, key) => fn(declaration, key, declaration.dataKey || key));
 
   // Construct the JSON API selector to map to props
@@ -69,7 +69,7 @@ const processDeclarations = (inputDeclarations, ...rest) => {
     // create a declaration object
     if (typeof inputDeclarations === 'string') {
       declarations = {};
-      forEach([inputDeclarations, ...rest], dataKey => {
+      forEach([inputDeclarations, ...rest], (dataKey) => {
         declarations[dataKey] = {};
       });
     }
@@ -200,7 +200,7 @@ const processDeclarations = (inputDeclarations, ...rest) => {
       };
 
       // Exposed, general nion data manipulating actions
-      dispatchProps[key].updateRef = ref => {
+      dispatchProps[key].updateRef = (ref) => {
         // TODO (legacied no-unused-vars)
         // This failure is legacied in and should be updated. DO NOT COPY.
         // eslint-disable-next-line no-unused-vars
@@ -257,7 +257,7 @@ const processDeclarations = (inputDeclarations, ...rest) => {
       // Add each method's corresponding request handler to the nextProps[key].request
       // object
       const methods = ['GET', 'PATCH', 'PUT', 'POST'];
-      methods.forEach(method => {
+      methods.forEach((method) => {
         const dispatchFn = dispatchProps[key][method];
         set(nextProps.nion, [key, 'actions', method.toLowerCase()], dispatchFn);
       });
@@ -299,138 +299,135 @@ const processDeclarations = (inputDeclarations, ...rest) => {
 };
 
 // JSON API decorator function for wrapping connected components to the new JSON API redux system
-const nion = (declarations = {}, ...rest) => WrappedComponent => {
-  const { mapStateToProps, mapDispatchToProps, mergeProps } = processDeclarations(declarations, ...rest);
+const nion =
+  (declarations = {}, ...rest) =>
+  (WrappedComponent) => {
+    const { mapStateToProps, mapDispatchToProps, mergeProps } = processDeclarations(declarations, ...rest);
 
-  // Track the status of fetch actions to avoid sending out duplicate requests, since props can
-  // change multiple times before the redux store has updated (our nion actions are async)
-  const fetchesByDataKey = {};
+    // Track the status of fetch actions to avoid sending out duplicate requests, since props can
+    // change multiple times before the redux store has updated (our nion actions are async)
+    const fetchesByDataKey = {};
 
-  // TODO (legacied react-prefer-function-component/react-prefer-function-component)
-  // This failure is legacied in and should be updated. DO NOT COPY.
-  // eslint-disable-next-line react-prefer-function-component/react-prefer-function-component
-  class WithNion extends Component {
-    static displayName = `WithNion(${getDisplayName(WrappedComponent)})`;
+    // TODO (legacied react-prefer-function-component/react-prefer-function-component)
+    // This failure is legacied in and should be updated. DO NOT COPY.
+    // eslint-disable-next-line react-prefer-function-component/react-prefer-function-component
+    class WithNion extends Component {
+      static displayName = `WithNion(${getDisplayName(WrappedComponent)})`;
 
-    static propTypes = {
-      nion: PropTypes.object.isRequired,
-    };
+      static propTypes = {
+        nion: PropTypes.object.isRequired,
+      };
 
-    constructor(props) {
-      super(props);
-      this.initializeDataKeys(props);
-    }
+      constructor(props) {
+        super(props);
+        this.initializeDataKeys(props);
+      }
 
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      this.initializeDataKeys(nextProps);
-    }
+      UNSAFE_componentWillReceiveProps(nextProps) {
+        this.initializeDataKeys(nextProps);
+      }
 
-    fetchOnMount(props) {
-      const { nion } = props; // eslint-disable-line no-shadow
+      fetchOnMount(props) {
+        const { nion } = props; // eslint-disable-line no-shadow
 
-      // We want to trigger a fetch when the props change and lead to the creation of a new
-      // dataKey, regardless of whether or not that happens as a result of a mount.
-      forEach(nion._declarations, (declaration, key) => {
-        // If not fetching on init, don't do anything
-        if (!declaration.fetchOnInit) {
-          return;
-        }
-
-        const fetch = nion[key].actions.get;
-        const status = nion[key].request.status;
-        const dataKey = declaration.dataKey;
-
-        // We need to manually check the status of the pending fetch action promise, since
-        // parent components may send props multiple times to the wrapped component (ie
-        // during setState). Because our redux actions are async, the redux store will not
-        // be updated before the next componentWillReceiveProps, so looking at the redux
-        // request status will be misleading because it will not have been updated
-        const isFetchPending = !!fetchesByDataKey[dataKey];
-
-        // If the fetch is only to be performed once, don't fetch if already loaded
-        if (declaration.fetchOnce) {
-          if (isNotLoaded(status) && !isFetchPending) {
-            fetchesByDataKey[dataKey] = fetch().then(() => {
-              fetchesByDataKey[dataKey] = null;
-            });
-          }
-        } else {
-          if (isNotLoading(status) && !isFetchPending) {
-            fetchesByDataKey[dataKey] = fetch().then(() => {
-              fetchesByDataKey[dataKey] = null;
-            });
-          }
-        }
-      });
-    }
-
-    initializeDataKeys(props) {
-      const { nion } = props; // eslint-disable-line no-shadow
-
-      // Iterate over the declarations provided to the component, deciding how to manage the
-      // load state of each one
-      forEach(nion._declarations, (declaration, key) => {
-        // If we're supplying a ref to be managed by nion, we'll want to attach it to the
-        // state tree ahead of time (maybe not? maybe we want to have a "virtual" ref...
-        // this is interesting)
-        if (declaration.initialRef) {
-          // If a ref has already been attached to the dataKey, don't dispatch it again...
-          // this triggers a cascading rerender which will cause an infinite loop
-
-          if (exists(nion[key].data)) {
+        // We want to trigger a fetch when the props change and lead to the creation of a new
+        // dataKey, regardless of whether or not that happens as a result of a mount.
+        forEach(nion._declarations, (declaration, key) => {
+          // If not fetching on init, don't do anything
+          if (!declaration.fetchOnInit) {
             return;
           }
 
-          const { dataKey, initialRef } = declaration;
-          // TODO (legacied consistent-return)
-          // This failure is legacied in and should be updated. DO NOT COPY.
-          // eslint-disable-next-line consistent-return
-          return nion._initializeDataKey(dataKey, initialRef);
-        }
-      });
+          const fetch = nion[key].actions.get;
+          const status = nion[key].request.status;
+          const dataKey = declaration.dataKey;
+
+          // We need to manually check the status of the pending fetch action promise, since
+          // parent components may send props multiple times to the wrapped component (ie
+          // during setState). Because our redux actions are async, the redux store will not
+          // be updated before the next componentWillReceiveProps, so looking at the redux
+          // request status will be misleading because it will not have been updated
+          const isFetchPending = !!fetchesByDataKey[dataKey];
+
+          // If the fetch is only to be performed once, don't fetch if already loaded
+          if (declaration.fetchOnce) {
+            if (isNotLoaded(status) && !isFetchPending) {
+              fetchesByDataKey[dataKey] = fetch().then(() => {
+                fetchesByDataKey[dataKey] = null;
+              });
+            }
+          } else {
+            if (isNotLoading(status) && !isFetchPending) {
+              fetchesByDataKey[dataKey] = fetch().then(() => {
+                fetchesByDataKey[dataKey] = null;
+              });
+            }
+          }
+        });
+      }
+
+      initializeDataKeys(props) {
+        const { nion } = props; // eslint-disable-line no-shadow
+
+        // Iterate over the declarations provided to the component, deciding how to manage the
+        // load state of each one
+        forEach(nion._declarations, (declaration, key) => {
+          // If we're supplying a ref to be managed by nion, we'll want to attach it to the
+          // state tree ahead of time (maybe not? maybe we want to have a "virtual" ref...
+          // this is interesting)
+          if (declaration.initialRef) {
+            // If a ref has already been attached to the dataKey, don't dispatch it again...
+            // this triggers a cascading rerender which will cause an infinite loop
+
+            if (exists(nion[key].data)) {
+              return;
+            }
+
+            const { dataKey, initialRef } = declaration;
+            // TODO (legacied consistent-return)
+            // This failure is legacied in and should be updated. DO NOT COPY.
+            // eslint-disable-next-line consistent-return
+            return nion._initializeDataKey(dataKey, initialRef);
+          }
+        });
+      }
+
+      componentDidMount() {
+        this.fetchOnMount(this.props);
+      }
+
+      render() {
+        // Filter out internally used props to not expose them in the wrapped component
+        const nextProps = {
+          ...this.props,
+          nion: finalProcessProps(this.props.nion),
+        };
+
+        return <WrappedComponent {...nextProps} />;
+      }
     }
 
-    componentDidMount() {
-      this.fetchOnMount(this.props);
-    }
-
-    render() {
-      // Filter out internally used props to not expose them in the wrapped component
-      const nextProps = {
-        ...this.props,
-        nion: finalProcessProps(this.props.nion),
-      };
-
-      return <WrappedComponent {...nextProps} />;
-    }
-  }
-
-  const connectedComponent = connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps,
-    {
+    const connectedComponent = connect(mapStateToProps, mapDispatchToProps, mergeProps, {
       areMergedPropsEqual,
-    },
-  )(WithNion);
-  // Take all static properties on the inner Wrapped component and put them on our now-connected
-  // component. // This makes nion transparent and safe to add as a decorator; it does not occlude
-  // the shape of the inner component.
-  difference(Object.keys(WrappedComponent), Object.keys(connectedComponent)).map(key => {
-    connectedComponent[key] = WrappedComponent[key];
-  });
-  // Remove nion from the propTypes of the connected component, if it exists,
-  // since it will be injected by withNion
-  if (connectedComponent.propTypes) {
-    // TODO (legacied no-unused-vars)
-    // This failure is legacied in and should be updated. DO NOT COPY.
-    // eslint-disable-next-line no-unused-vars
-    const { nion: _, ...restProps } = connectedComponent.propTypes;
-    connectedComponent.propTypes = restProps;
-  }
+    })(WithNion);
+    // Take all static properties on the inner Wrapped component and put them on our now-connected
+    // component. // This makes nion transparent and safe to add as a decorator; it does not occlude
+    // the shape of the inner component.
+    difference(Object.keys(WrappedComponent), Object.keys(connectedComponent)).map((key) => {
+      connectedComponent[key] = WrappedComponent[key];
+    });
+    // Remove nion from the propTypes of the connected component, if it exists,
+    // since it will be injected by withNion
+    if (connectedComponent.propTypes) {
+      // TODO (legacied no-unused-vars)
+      // This failure is legacied in and should be updated. DO NOT COPY.
+      // eslint-disable-next-line no-unused-vars
+      const { nion: _, ...restProps } = connectedComponent.propTypes;
+      connectedComponent.propTypes = restProps;
+    }
 
-  return connectedComponent;
-};
+    return connectedComponent;
+  };
 
 // TODO (legacied import/no-default-export)
 // This failure is legacied in and should be updated. DO NOT COPY.

--- a/src/denormalize/cache.js
+++ b/src/denormalize/cache.js
@@ -18,6 +18,7 @@ export function mergeManifests(a, b) {
 
   return a;
 }
+
 class DenormalizationCache {
   denorm = {};
   manifests = {};
@@ -91,13 +92,5 @@ class DenormalizationCache {
   };
 }
 
-const denormalizationCache = new DenormalizationCache();
+export { DenormalizationCache };
 
-// TODO (legacied import/no-default-export)
-// This failure is legacied in and should be updated. DO NOT COPY.
-// eslint-disable-next-line import/no-default-export
-export default denormalizationCache;
-
-export function purgeDenormalizationCache() {
-  denormalizationCache.purge();
-}

--- a/src/denormalize/cache.js
+++ b/src/denormalize/cache.js
@@ -24,12 +24,6 @@ class DenormalizationCache {
   manifests = {};
   entities = {};
 
-  purge = () => {
-    this.denorm = {};
-    this.manifests = {};
-    this.entities = {};
-  };
-
   initializeManifest = (ref) => ({ [ref.type]: { [ref.id]: ref } });
 
   addDenormalized = (type, id, data) => {

--- a/src/denormalize/cache.js
+++ b/src/denormalize/cache.js
@@ -93,4 +93,3 @@ class DenormalizationCache {
 }
 
 export { DenormalizationCache };
-

--- a/src/denormalize/denormalize.test.js
+++ b/src/denormalize/denormalize.test.js
@@ -1,24 +1,27 @@
 import { EntityStoreManager, makeUserEntity, makeFriendEntity, makeFriendsEntity } from './test.helpers';
 import denormalize from './index';
-import cache from './cache';
+import { DenormalizationCache } from './cache';
 
 describe('nion/denormalize', () => {
   describe('simple denormalization', () => {
     it('an empty ref returns an empty array', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const ref = { entities: [] };
-      const object = denormalize(ref, entityStoreManager.store);
+      const object = denormalize(ref, entityStoreManager.store, cache);
       expect(object.length).toEqual(0);
     });
 
     it('an undefined ref returns undefined', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const ref = { entities: [undefined] };
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
       expect(object).toEqual(undefined);
     });
 
     it('simple entity with no relationships is denormalized', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       entityStoreManager.addEntity(userEntity);
@@ -26,7 +29,7 @@ describe('nion/denormalize', () => {
       const { type, id } = userEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
 
       expect(object.type).toEqual(userEntity.type);
       expect(object.id).toEqual(userEntity.id);
@@ -34,6 +37,7 @@ describe('nion/denormalize', () => {
     });
 
     it('A simple entity with a relationship is denormalized', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const friendEntity = makeFriendEntity(userEntity.id);
@@ -44,7 +48,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
 
       expect(object.type).toEqual(friendEntity.type);
       expect(object.id).toEqual(friendEntity.id);
@@ -55,6 +59,7 @@ describe('nion/denormalize', () => {
     });
 
     it('A simple entity with plural relationships is denormalized', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const userEntity2 = makeUserEntity();
@@ -67,7 +72,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendsEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
 
       expect(object.type).toEqual(friendsEntity.type);
       expect(object.id).toEqual(friendsEntity.id);
@@ -85,6 +90,7 @@ describe('nion/denormalize', () => {
 
   describe('complex denormalization', () => {
     it('An entity with a child that is also a grandchild and a parent (A->C->G->A, A->G->A)', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       entityStoreManager.addEntity({
         type: 'rootNode',
@@ -123,7 +129,7 @@ describe('nion/denormalize', () => {
         type: 'other',
         id: 'other1',
       });
-      const [rootNode] = denormalize({ entities: [{ type: 'rootNode', id: 'rootNode1' }] }, entityStoreManager.store);
+      const [rootNode] = denormalize({ entities: [{ type: 'rootNode', id: 'rootNode1' }] }, entityStoreManager.store, cache);
       expect(rootNode.grandchild.rootNode).toEqual({
         type: 'rootNode',
         id: 'rootNode1',
@@ -137,6 +143,7 @@ describe('nion/denormalize', () => {
     });
 
     it('An entity with a child and an array of grandchildren, and the grandchildren are also a parents (A->C->G[0]->A, A->G[*]->A)', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       entityStoreManager.addEntity({
         type: 'rootNode',
@@ -194,7 +201,7 @@ describe('nion/denormalize', () => {
         type: 'other',
         id: 'other2',
       });
-      const [rootNode] = denormalize({ entities: [{ type: 'rootNode', id: 'rootNode1' }] }, entityStoreManager.store);
+      const [rootNode] = denormalize({ entities: [{ type: 'rootNode', id: 'rootNode1' }] }, entityStoreManager.store, cache);
       expect(rootNode.child.grandchild.rootNode).toEqual({
         type: 'rootNode',
         id: 'rootNode1',
@@ -230,6 +237,7 @@ describe('nion/denormalize', () => {
 
   describe('denormalization caching', () => {
     it('Denormalizing adds the immutable entity to the cache', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const entity = entityStoreManager.addEntity(userEntity);
@@ -237,12 +245,13 @@ describe('nion/denormalize', () => {
       const { type, id } = userEntity;
       const ref = { entities: [{ type, id }] };
 
-      denormalize(ref, entityStoreManager.store);
+      denormalize(ref, entityStoreManager.store, cache);
       const cachedEntity = cache.getEntity(type, id);
       expect(entity).toEqual(cachedEntity);
     });
 
     it('Denormalizing adds the immutable object to the cache', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       entityStoreManager.addEntity(userEntity);
@@ -250,12 +259,13 @@ describe('nion/denormalize', () => {
       const { type, id } = userEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
       const cachedObject = cache.getDenormalized(type, id);
       expect(object).toEqual(cachedObject);
     });
 
     it('Denormalizing a ref with relationships adds manifest to the cache', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const friendEntity = makeFriendEntity(userEntity.id);
@@ -265,7 +275,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendEntity;
       const ref = { entities: [{ type, id }] };
 
-      denormalize(ref, entityStoreManager.store);
+      denormalize(ref, entityStoreManager.store, cache);
 
       const manifest = cache.getManifest(type, id);
 
@@ -277,6 +287,7 @@ describe('nion/denormalize', () => {
     });
 
     it('If entities in the manifest have not changed, it returns the cached object', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const friendEntity = makeFriendEntity(userEntity.id);
@@ -286,18 +297,19 @@ describe('nion/denormalize', () => {
       const { type, id } = friendEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [firstObject] = denormalize(ref, entityStoreManager.store);
+      const [firstObject] = denormalize(ref, entityStoreManager.store, cache);
 
       // Add another, unrelated entity to the store
       const userEntity2 = makeUserEntity();
       entityStoreManager.addEntity(userEntity2);
 
       // Fetch the denormalized object again - it should be cached
-      const [secondObject] = denormalize(ref, entityStoreManager.store);
+      const [secondObject] = denormalize(ref, entityStoreManager.store, cache);
       expect(firstObject).toEqual(secondObject);
     });
 
     it('If entities in the manifest have changed, it returns a new denormalized object', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const friendEntity = makeFriendEntity(userEntity.id);
@@ -307,7 +319,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [firstObject] = denormalize(ref, entityStoreManager.store);
+      const [firstObject] = denormalize(ref, entityStoreManager.store, cache);
 
       // Update the related entity, which should force a re-denormalization
       entityStoreManager.updateEntity({
@@ -319,12 +331,13 @@ describe('nion/denormalize', () => {
       });
 
       // Fetch the denormalized object again, it should be reconstructed
-      const [secondObject] = denormalize(ref, entityStoreManager.store);
+      const [secondObject] = denormalize(ref, entityStoreManager.store, cache);
       expect(firstObject === secondObject).toEqual(false);
       expect(secondObject.friend.favoriteColor).toEqual('blue');
     });
 
     it('If an entity is added to the relationship, it returns a new denormalized object', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const userEntity2 = makeUserEntity();
@@ -339,7 +352,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendsEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [firstObject] = denormalize(ref, entityStoreManager.store);
+      const [firstObject] = denormalize(ref, entityStoreManager.store, cache);
 
       // Now add a new entity to the store and add it as a relationship to the target object
       const userEntity3 = makeUserEntity();
@@ -364,7 +377,7 @@ describe('nion/denormalize', () => {
 
       // Fetch the denormalized object again, it should be reconstructed, but the previously
       // cached objects should remain the same
-      const [secondObject] = denormalize(ref, entityStoreManager.store);
+      const [secondObject] = denormalize(ref, entityStoreManager.store, cache);
       expect(firstObject === secondObject).toEqual(false);
       expect(secondObject.friends).toHaveLength(3);
 
@@ -373,6 +386,7 @@ describe('nion/denormalize', () => {
     });
 
     it('If an entity is removed from the relationship, it returns a new denormalized object', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const userEntity2 = makeUserEntity();
@@ -389,7 +403,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendsEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [firstObject] = denormalize(ref, entityStoreManager.store);
+      const [firstObject] = denormalize(ref, entityStoreManager.store, cache);
 
       // Update the target entity, which should force a re-denormalization
       const { data } = friendsEntity.relationships.friends;
@@ -406,7 +420,7 @@ describe('nion/denormalize', () => {
 
       // Fetch the denormalized object again, it should be reconstructed, but the previously
       // cached objects should remain the same
-      const [secondObject] = denormalize(ref, entityStoreManager.store);
+      const [secondObject] = denormalize(ref, entityStoreManager.store, cache);
       expect(firstObject === secondObject).toEqual(false);
       expect(secondObject.friends).toHaveLength(2);
 
@@ -415,6 +429,7 @@ describe('nion/denormalize', () => {
     });
 
     it('If a related entity is deleted from the store, it returns a new denormalized object', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const userEntity2 = makeUserEntity();
@@ -431,13 +446,13 @@ describe('nion/denormalize', () => {
       const { type, id } = friendsEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [firstObject] = denormalize(ref, entityStoreManager.store);
+      const [firstObject] = denormalize(ref, entityStoreManager.store, cache);
 
       entityStoreManager.removeEntity(userEntity3);
 
       // Fetch the denormalized object again, it should be reconstructed, but the previously
       // cached objects should remain the same
-      const [secondObject] = denormalize(ref, entityStoreManager.store);
+      const [secondObject] = denormalize(ref, entityStoreManager.store, cache);
       expect(firstObject === secondObject).toEqual(false);
       expect(secondObject.friends).toHaveLength(3);
 
@@ -447,6 +462,7 @@ describe('nion/denormalize', () => {
     });
 
     it('Handles updates to deeply nested entities', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
 
       // Set up this relationship:
@@ -469,7 +485,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendsEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [firstObject] = denormalize(ref, entityStoreManager.store);
+      const [firstObject] = denormalize(ref, entityStoreManager.store, cache);
 
       entityStoreManager.updateEntity({
         type: userEntity3.type,
@@ -481,7 +497,7 @@ describe('nion/denormalize', () => {
 
       // Fetch the denormalized object again, it should be reconstructed, but the previously
       // cached objects should remain the same
-      const [secondObject] = denormalize(ref, entityStoreManager.store);
+      const [secondObject] = denormalize(ref, entityStoreManager.store, cache);
       expect(firstObject === secondObject).toEqual(false);
       expect(secondObject.friends).toHaveLength(3);
 
@@ -494,6 +510,7 @@ describe('nion/denormalize', () => {
 
   describe('extra properties', () => {
     it('adds an _exists property the denormalized data', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       entityStoreManager.addEntity(userEntity);
@@ -501,11 +518,12 @@ describe('nion/denormalize', () => {
       const { type, id } = userEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
       expect(object._exists).toEqual(true);
     });
 
     it('adds a _ref property of to the original ref being denormalized', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       entityStoreManager.addEntity(userEntity);
@@ -513,11 +531,12 @@ describe('nion/denormalize', () => {
       const { type, id } = userEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
       expect(object._ref).toMatchObject({ data: { type, id } });
     });
 
     it('adds a _ref property of a relationship being denormalized', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const friendEntity = makeFriendEntity(userEntity.id);
@@ -527,7 +546,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
 
       expect(object.friend._ref).toMatchObject({
         data: {
@@ -538,6 +557,7 @@ describe('nion/denormalize', () => {
     });
 
     it('adds a _ref property to a plural relationship being denormalized', () => {
+      const cache = new DenormalizationCache();
       const entityStoreManager = new EntityStoreManager();
       const userEntity = makeUserEntity();
       const friendsEntity = makeFriendsEntity([userEntity.id]);
@@ -547,7 +567,7 @@ describe('nion/denormalize', () => {
       const { type, id } = friendsEntity;
       const ref = { entities: [{ type, id }] };
 
-      const [object] = denormalize(ref, entityStoreManager.store);
+      const [object] = denormalize(ref, entityStoreManager.store, cache);
 
       expect(object.friends._ref).toMatchObject({
         data: [

--- a/src/denormalize/denormalize.test.js
+++ b/src/denormalize/denormalize.test.js
@@ -129,7 +129,11 @@ describe('nion/denormalize', () => {
         type: 'other',
         id: 'other1',
       });
-      const [rootNode] = denormalize({ entities: [{ type: 'rootNode', id: 'rootNode1' }] }, entityStoreManager.store, cache);
+      const [rootNode] = denormalize(
+        { entities: [{ type: 'rootNode', id: 'rootNode1' }] },
+        entityStoreManager.store,
+        cache,
+      );
       expect(rootNode.grandchild.rootNode).toEqual({
         type: 'rootNode',
         id: 'rootNode1',
@@ -201,7 +205,11 @@ describe('nion/denormalize', () => {
         type: 'other',
         id: 'other2',
       });
-      const [rootNode] = denormalize({ entities: [{ type: 'rootNode', id: 'rootNode1' }] }, entityStoreManager.store, cache);
+      const [rootNode] = denormalize(
+        { entities: [{ type: 'rootNode', id: 'rootNode1' }] },
+        entityStoreManager.store,
+        cache,
+      );
       expect(rootNode.child.grandchild.rootNode).toEqual({
         type: 'rootNode',
         id: 'rootNode1',

--- a/src/denormalize/index.js
+++ b/src/denormalize/index.js
@@ -1,6 +1,6 @@
 import Immutable from 'seamless-immutable';
 import { camelize, camelizeKeys } from 'humps';
-import cache, { mergeManifests } from './cache';
+import { mergeManifests } from './cache';
 
 class GenericData {
   constructor(data) {
@@ -72,7 +72,7 @@ export const hasEntityReference = (obj) => Boolean(getEntityReference(obj));
 // Since all denormalized objects in the cache are immutable, we can very easily compare them
 // in downstream selectors, redux connect functions, or componentShouldUpdate methods to optimize
 // re-render performance
-function denormalize(ref, entityStore, existingObjects = {}) {
+function denormalize(ref, entityStore, cache, existingObjects = {}) {
   if (!(ref?.type && ref?.id)) {
     return { denormalized: undefined };
   }
@@ -144,7 +144,7 @@ function denormalize(ref, entityStore, existingObjects = {}) {
     const existingObjectsCopy = Object.assign({}, existingObjects);
 
     if (!Array.isArray(refOrRefs)) {
-      const { denormalized, related } = denormalize(refOrRefs, entityStore, existingObjectsCopy);
+      const { denormalized, related } = denormalize(refOrRefs, entityStore, cache, existingObjectsCopy);
 
       toSet = denormalized;
 
@@ -154,7 +154,7 @@ function denormalize(ref, entityStore, existingObjects = {}) {
       // This failure is legacied in and should be updated. DO NOT COPY.
       // eslint-disable-next-line no-inner-declarations
       function mapCollection(_ref) {
-        const { denormalized, related } = denormalize(_ref, entityStore, existingObjectsCopy);
+        const { denormalized, related } = denormalize(_ref, entityStore, cache, existingObjectsCopy);
 
         mergeManifests(manifest, related);
 
@@ -196,8 +196,8 @@ function denormalize(ref, entityStore, existingObjects = {}) {
   return { denormalized: obj, related: manifest };
 }
 
-export const denormalizeEntities = (ref, entityStore) =>
-  ref.entities.map((entity) => denormalize(entity, entityStore).denormalized);
+export const denormalizeEntities = (ref, entityStore, cache) =>
+  ref.entities.map((entity) => denormalize(entity, entityStore, cache).denormalized);
 
 // TODO (legacied import/no-default-export)
 // This failure is legacied in and should be updated. DO NOT COPY.

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,10 +4,20 @@ import references from './references';
 import requests from './requests';
 import entities from './entities';
 
+import { DenormalizationCache } from '../denormalize/cache';
+
+function denormalizationCacheReducer(state) {
+  if (!state) {
+    return new DenormalizationCache();
+  }
+  return state;
+}
+
 // TODO (legacied import/no-default-export)
 // This failure is legacied in and should be updated. DO NOT COPY.
 // eslint-disable-next-line import/no-default-export
 export default combineReducers({
+  __dCache: denormalizationCacheReducer,
   references,
   requests,
   entities,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,6 +6,10 @@ import entities from './entities';
 
 import { DenormalizationCache } from '../denormalize/cache';
 
+// We're storing a singleton instance of the denormlization cache in
+// the redux store (behind the nested __dCache key). This is admittedly
+// odd, but a means to make the cache request-local rather than global
+// during server-side execution.
 function denormalizationCacheReducer(state) {
   if (!state) {
     return new DenormalizationCache();

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -15,7 +15,9 @@ const selectReferences = createSelector([selectNion], (nion) => nion && nion.ref
 
 const selectRequests = createSelector([selectNion], (nion) => nion && nion.requests);
 
-const denormalizeRef = (ref, entityStore) => {
+const selectDenormalizedCache = (state) => state?.nion?.__dCache;
+
+const denormalizeRef = (ref, entityStore, dCache) => {
   // If the ref is a generic (eg a primitive from a non-json-api response), return the ref
 
   // JB (in ref to the comment above)
@@ -25,7 +27,7 @@ const denormalizeRef = (ref, entityStore) => {
     return getGenericRefData(ref);
   }
 
-  const denormalized = denormalizeEntities(ref, entityStore);
+  const denormalized = denormalizeEntities(ref, entityStore, dCache);
 
   return ref.isCollection ? denormalized : denormalized[0];
 };
@@ -63,8 +65,9 @@ export const selectRequest = (key) => {
 
 const selectObj = (key) => {
   if (!selectByKey.obj[key]) {
-    selectByKey.obj[key] = createSelector([selectRef(key), selectEntities], (ref, entityStore) =>
-      denormalizeRef(ref, entityStore),
+    selectByKey.obj[key] = createSelector(
+      [selectRef(key), selectEntities, selectDenormalizedCache],
+      (ref, entityStore, dCache) => denormalizeRef(ref, entityStore, dCache),
     );
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,8 +87,6 @@ export function initializeNionDevTool(store: NionReduxState): void;
 
 export function titleFormatter(action: symbol, time: any, took: number): string;
 
-export function purgeDenormalizationCache(): void;
-
 export const actions: Actions<any>;
 
 export interface CommonDeclarationValues {


### PR DESCRIPTION
## Background

Nion was not explicitly designed to run on the server. The clearest indication of this is the `DenormalizationCache` singleton, which uses an unbounded set of objects to hang onto denormalized entities.

This works great on the client, but leaks memory on the server unless explicitly purged. With the upcoming adoption of React Server Components, we no longer have a lifecycle hook to flush the cache as rendering can happen concurrently across trees.

To work around this, we have a few options, but the safest thing to do is to localize the cache within the store itself. Thankfully there is a single entrypoint at which we access this cache – a selector – which we can take advantage of for our use case.

## Testing

I've built this locally and verified against PRF. Will share more context and validation in an upcoming PRF PR.