### PR TITLE
Don't cache selectors on the server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,5 @@ export { purgeDenormalizationCache } from './denormalize/cache';
 export { default as initializeNionDevTool } from './devtool';
 export { default as useNion } from './hook/useNion';
 export { titleFormatter } from './logger';
-export {
-  purgeSelectorCache,
-  selectData,
-  selectObjectWithRequest,
-  selectRequest,
-  selectResourcesForKeys,
-} from './selectors';
+export { selectData, selectObjectWithRequest, selectRequest, selectResourcesForKeys } from './selectors';
 export { makeRef } from './transforms';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,8 +61,6 @@ export interface NionValue<T> extends NionRefHolder {
 
 export function exists<T>(value?: NionValue<T> | null): value is NionValue<T>;
 
-export function purgeSelectorCache(): void;
-
 export function selectData<T>(key: string, defaultValue?: any): OutputSelector<NionReduxState, T, any>;
 
 export function selectRequest(key: string): OutputSelector<NionReduxState, NionRequest, any>;


### PR DESCRIPTION
## Background

Similar to #160, this PR includes a runtime change to avoid leaking memory on the server. The `selectByKey` module global in the selectors module makes use of unbounded objects to hang onto selectors. This makes perfect sense, but when this code executes across requests on the server, this leaks memory. This happens because the selectors being created contain closures linking to immutable data structures (which can be quite large).

To account for this, an escape hatch API was added in #150, however, in order to unlock safe concurrent rendering we need to make a change here.

## Solution

The simplest thing to do here is to remove the caching entirely. However, these codepaths run fairly hot on the client, and doing so will likely regress INP performance. The next simplest thing to do is to opt-out of caching these selectors on the server – this is what I've opted to do in this PR behind a static `typeof window === 'undefined'` check.

## Testing

I've built this locally and verified against PRF.