### PR TITLE
Export DenormalizationCache, add type export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export { default as actions } from './actions';
 export { default as bootstrapNion } from './bootstrap';
 export { default as configureNion } from './configure';
 export { exists } from './decorator';
-export { purgeDenormalizationCache } from './denormalize/cache';
+export { DenormalizationCache } from './denormalize/cache';
 export { default as initializeNionDevTool } from './devtool';
 export { default as useNion } from './hook/useNion';
 export { titleFormatter } from './logger';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -123,6 +123,8 @@ export interface InferableComponentEnhancerWithProps<TNeedsProps, TInferProps> {
   >;
 }
 
+export class DenormalizationCache {}
+
 export type HOCProps = {
   nion: { [dataKey: string]: NionValue<any> };
 };


### PR DESCRIPTION
Since we've moved this into store, we occasionally need it for some of our older tests which scaffold out mock nion states.