### PR TITLE
Provide the cache to all denormalizeRef calls

### DIFF
--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -118,13 +118,14 @@ export const selectData = (key, defaultValue) => {
 
     if (!selectByKey.data[selectorKey]) {
       const selector = createSelector(
-        [selectEntities],
-        (entityStore) =>
+        [selectEntities, selectDenormalizedCache],
+        (entityStore, dCache) =>
           denormalizeRef(
             {
               entities: [{ type: key.type, id: key.id }],
             },
             entityStore,
+            dCache,
           ) || defaultValue,
       );
       if (isServer) {


### PR DESCRIPTION
I missed a callsite when wiring up the cache selector in #160.