### PR TITLE
Improve Nion Types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,8 +88,8 @@ export function titleFormatter(action: symbol, time: any, took: number): string;
 export const actions: Actions<any>;
 
 export interface CommonDeclarationValues {
-  endpoint: string;
-  initialRef?: NionRef;
+  endpoint?: string;
+  initialRef?: ReturnType<typeof makeRef>;
   extensions?: any;
   apiType?: string;
   requestParams?: any;


### PR DESCRIPTION
This PR fixes some Nion typing issues. It's simpler than https://github.com/Patreon/nion/pull/167, which I want to think more on.

- `endpoint` should be optional as we can pass it in via params.
- `initialRef` is always passed the value of `makeRef()`, so the type should match.